### PR TITLE
Update README.md to include install instructions for AUR based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ brew tap cherryservers/cherryctl
 brew install cherryctl
 ```
 
+### Install `cherryctl` from the [AUR]([https://brew.sh/](https://aur.archlinux.org/packages/cherryctl)
+
+```sh
+paru -S cherryctl
+```
+
 ### Install `cherryctl` from Source
 
 If you have `go` 1.17 or later installed, you can build and install the latest development version with:


### PR DESCRIPTION
I added a `PKGBUILD` for arch-based systems to the AUR, since the default installer at `scripts/build.sh` uses `darwin` & `arm` & updated the docs accordingly.

The `PKGBUILD` will also create a cherry config file if it doesn't already exist:

```bash
  dir_path="$HOME/.config/cherry"
  if [ ! -d "$dir_path" ] || [ -z "$(find "$dir_path" -maxdepth 1 -name '*.yaml' -print -quit)" ]; then
    mkdir -p "$dir_path"
    touch "$dir_path/default.yaml"
  fi

```