### PR TITLE
[ADD] bmc-password-reset

### DIFF
--- a/docs/cherryctl_server.md
+++ b/docs/cherryctl_server.md
@@ -4,7 +4,7 @@ Server operations. For more information on server types check Product Docs: http
 
 ### Synopsis
 
-Server operations: create, get, list, delete, start, stop, reboot and reinstall.
+Server operations: create, get, list, delete, start, stop, reboot, reinstall and reset-bmc-password.
 
 ### Options
 
@@ -32,6 +32,7 @@ Server operations: create, get, list, delete, start, stop, reboot and reinstall.
 * [cherryctl server list](cherryctl_server_list.md)	 - Retrieves server list.
 * [cherryctl server reboot](cherryctl_server_reboot.md)	 - Reboot a server.
 * [cherryctl server reinstall](cherryctl_server_reinstall.md)	 - Reinstall a server.
+* [cherryctl server reset-bmc-password](cherryctl_server_reset-bmc-password.md)	 - Reset server BMC password.
 * [cherryctl server start](cherryctl_server_start.md)	 - Starts a server.
 * [cherryctl server stop](cherryctl_server_stop.md)	 - Stop a server.
 * [cherryctl server update](cherryctl_server_update.md)	 - Update server.

--- a/docs/cherryctl_server_reset-bmc-password.md
+++ b/docs/cherryctl_server_reset-bmc-password.md
@@ -15,6 +15,8 @@ cherryctl server reset-bmc-password ID [flags]
 ```
   # Reset BMC password for the specified server:
   cherryctl server reset-bmc-password 12345
+  # Retrieve the new password:
+  cherryctl server get 12345 -o json | jq .bmc
 ```
 
 ### Options

--- a/docs/cherryctl_server_reset-bmc-password.md
+++ b/docs/cherryctl_server_reset-bmc-password.md
@@ -1,0 +1,40 @@
+## cherryctl server reset-bmc-password
+
+Reset server BMC password.
+
+### Synopsis
+
+Reset BMC password for the specified server.
+
+```
+cherryctl server reset-bmc-password ID [flags]
+```
+
+### Examples
+
+```
+  # Reset BMC password for the specified server:
+  cherryctl server reset-bmc-password 12345
+```
+
+### Options
+
+```
+  -h, --help   help for reset-bmc-password
+```
+
+### Options inherited from parent commands
+
+```
+      --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
+      --config string    Path to JSON or YAML configuration file
+      --context string   Specify a custom context name (default "default")
+      --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
+  -o, --output string    Output format (*table, json, yaml)
+      --token string     API Token (CHERRY_AUTH_TOKEN)
+```
+
+### SEE ALSO
+
+* [cherryctl server](cherryctl_server.md)	 - Server operations. For more information on server types check Product Docs: https://docs.cherryservers.com/knowledge/product-docs#compute
+

--- a/internal/servers/resetbmc.go
+++ b/internal/servers/resetbmc.go
@@ -14,7 +14,9 @@ func (c *Client) ResetBMC() *cobra.Command {
 		Short: "Reset server BMC password.",
 		Long:  "Reset BMC password for the specified server.",
 		Example: `  # Reset BMC password for the specified server:
-  cherryctl server reset-bmc-password 12345`,
+  cherryctl server reset-bmc-password 12345
+  # Retrieve the new password:
+  cherryctl server get 12345 -o json | jq .bmc`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true

--- a/internal/servers/resetbmc.go
+++ b/internal/servers/resetbmc.go
@@ -1,0 +1,37 @@
+package servers
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"strconv"
+)
+
+func (c *Client) ResetBMC() *cobra.Command {
+	resetServerBMCCmd := &cobra.Command{
+		Use:   `reset-bmc-password ID`,
+		Args:  cobra.ExactArgs(1),
+		Short: "Reset server BMC password.",
+		Long:  "Reset BMC password for the specified server.",
+		Example: `  # Reset BMC password for the specified server:
+  cherryctl server reset-bmc-password 12345`,
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			if serverID, err := strconv.Atoi(args[0]); err == nil {
+				_, _, err := c.Service.ResetBMCPassword(serverID)
+				if err != nil {
+					return errors.Wrap(err, "Could not reset server BMC password")
+				}
+
+				fmt.Println("Server", serverID, "BMC password successfully reset.")
+				return nil
+			}
+
+			fmt.Println("Server with ID %s was not found", args[0])
+			return nil
+		},
+	}
+
+	return resetServerBMCCmd
+}

--- a/internal/servers/server.go
+++ b/internal/servers/server.go
@@ -18,7 +18,7 @@ func (c *Client) NewCommand() *cobra.Command {
 		Use:     `server`,
 		Aliases: []string{"servers", "device", "devices"},
 		Short:   "Server operations. For more information on server types check Product Docs: https://docs.cherryservers.com/knowledge/product-docs#compute",
-		Long:    "Server operations: create, get, list, delete, start, stop, reboot and reinstall.",
+		Long:    "Server operations: create, get, list, delete, start, stop, reboot, reinstall and reset-bmc-password.",
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if root := cmd.Root(); root != nil {
@@ -41,6 +41,7 @@ func (c *Client) NewCommand() *cobra.Command {
 		c.Reboot(),
 		c.Reinstall(),
 		c.Delete(),
+		c.ResetBMC(),
 	)
 
 	return cmd


### PR DESCRIPTION
At least partially resolves https://github.com/cherryservers/cherryctl/issues/31. Since resetting BMC password is a server action and not a part of updating the server in API, it seemed sensible to implement a password reset as a separate command, akin to other actions, such as reboot and rebuild.