### PR TITLE
Fix documentation for BGP flag in `project create`.

### DIFF
--- a/docs/cherryctl_project_create.md
+++ b/docs/cherryctl_project_create.md
@@ -13,14 +13,14 @@ cherryctl project create -t <team_id> --name <project_name> [--bgp <bool>] [flag
 ### Examples
 
 ```
-  # To create a new project with BGP enabled:
-  cherryctl project create -t 12345 --name "Project with BGP" --bgp true
+  # To create a new project with BGP support enabled:
+  cherryctl project create -t 12345 --name "Project with BGP" --bgp
 ```
 
 ### Options
 
 ```
-  -b, --bgp           True to enable BGP in a project.
+  -b, --bgp           Enable BGP support.
   -h, --help          help for create
       --name string   Project name.
   -t, --team-id int   The teams's ID.

--- a/internal/projects/create.go
+++ b/internal/projects/create.go
@@ -19,8 +19,8 @@ func (c *Client) Create() *cobra.Command {
 		Use:   `create -t <team_id> --name <project_name> [--bgp <bool>]`,
 		Short: "Create a project.",
 		Long:  "Create a new project in a speficied team.",
-		Example: `  # To create a new project with BGP enabled:
-  cherryctl project create -t 12345 --name "Project with BGP" --bgp true`,
+		Example: `  # To create a new project with BGP support enabled:
+  cherryctl project create -t 12345 --name "Project with BGP" --bgp`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
@@ -43,7 +43,7 @@ func (c *Client) Create() *cobra.Command {
 	}
 
 	projectCreateCmd.Flags().IntVarP(&teamID, "team-id", "t", 0, "The teams's ID.")
-	projectCreateCmd.Flags().BoolVarP(&bgp, "bgp", "b", false, "True to enable BGP in a project.")
+	projectCreateCmd.Flags().BoolVarP(&bgp, "bgp", "b", false, "Enable BGP support.")
 	projectCreateCmd.Flags().StringVarP(&name, "name", "", "", "Project name.")
 
 	projectCreateCmd.MarkFlagRequired("team-id")


### PR DESCRIPTION
I've studied the code and it seems to me, that originally it was intended to use `--bgp` only as flag to enable BGP support when it's needed. It just somehow ended up with an overcomplicated and unclear description in documentation.

Fixed the documentation to make it clearer.