### PR TITLE
ssh-keys list doesn't require project id anymore

### DIFF
--- a/docs/cherryctl_ssh-key.md
+++ b/docs/cherryctl_ssh-key.md
@@ -29,6 +29,6 @@ Ssh-key operations: get, list, update, delete.
 * [cherryctl ssh-key create](cherryctl_ssh-key_create.md)	 - Adds an SSH key for the current user's account.
 * [cherryctl ssh-key delete](cherryctl_ssh-key_delete.md)	 - Deletes an SSH key.
 * [cherryctl ssh-key get](cherryctl_ssh-key_get.md)	 - Retrieves ssh-key details.
-* [cherryctl ssh-key list](cherryctl_ssh-key_list.md)	 - Retrieves project members ssh-keys details.
+* [cherryctl ssh-key list](cherryctl_ssh-key_list.md)	 - Retrieves ssh-keys.
 * [cherryctl ssh-key update](cherryctl_ssh-key_update.md)	 - Updates an SSH key.
 

--- a/docs/cherryctl_ssh-key_list.md
+++ b/docs/cherryctl_ssh-key_list.md
@@ -1,20 +1,20 @@
 ## cherryctl ssh-key list
 
-Retrieves project members ssh-keys details.
+Retrieves ssh-keys.
 
 ### Synopsis
 
-Retrieves project members ssh-keys details.
+Retrieves ssh-keys. If the project ID is specified, will return all SSH keys assigned to a specific project.
 
 ```
-cherryctl ssh-key list -p <project_id> [flags]
+cherryctl ssh-key list [-p <project_id>] [flags]
 ```
 
 ### Examples
 
 ```
-  # List of project ssh-keys:
-  cherryctl ssh-key list -i 12345
+  # List of ssh-keys:
+  cherryctl ssh-key list
 ```
 
 ### Options

--- a/internal/sshkeys/list.go
+++ b/internal/sshkeys/list.go
@@ -1,6 +1,7 @@
 package sshkeys
 
 import (
+	"github.com/cherryservers/cherrygo/v3"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -10,16 +11,24 @@ import (
 func (c *Client) List() *cobra.Command {
 	var projectID int
 	sshListCmd := &cobra.Command{
-		Use:   `list -p <project_id>`,
-		Short: "Retrieves project members ssh-keys details.",
-		Long:  "Retrieves project members ssh-keys details.",
-		Example: `  # List of project ssh-keys:
-  cherryctl ssh-key list -i 12345`,
+		Use:   `list [-p <project_id>]`,
+		Short: "Retrieves ssh-keys.",
+		Long:  "Retrieves ssh-keys. If the project ID is specified, will return all SSH keys assigned to a specific project.",
+		Example: `  # List of ssh-keys:
+  cherryctl ssh-key list`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			getOptions := c.Servicer.GetOptions()
 			getOptions.Fields = []string{"ssh_key", "email"}
-			sshKeys, _, err := c.ProjectsService.ListSSHKeys(projectID, getOptions)
+
+			var sshKeys []cherrygo.SSHKey
+			err := error(nil)
+			if projectID != 0 {
+				sshKeys, _, err = c.ProjectsService.ListSSHKeys(projectID, getOptions)
+			} else {
+				sshKeys, _, err = c.Service.List(getOptions)
+			}
+
 			if err != nil {
 				return errors.Wrap(err, "Could not get ssh-keys list")
 			}
@@ -35,7 +44,6 @@ func (c *Client) List() *cobra.Command {
 	}
 
 	sshListCmd.Flags().IntVarP(&projectID, "project-id", "p", 0, "The project's ID.")
-	sshListCmd.MarkFlagRequired("project-id")
 
 	return sshListCmd
 }


### PR DESCRIPTION
Resolves https://github.com/cherryservers/cherryctl/issues/48.