### PR TITLE
Fix server creation docs.

### DIFF
--- a/docs/cherryctl_server_create.md
+++ b/docs/cherryctl_server_create.md
@@ -4,17 +4,17 @@ Create a server.
 
 ### Synopsis
 
-Create a server in speficied project.
+Create a server in specified project.
 
 ```
-cherryctl server create -p <project_id> --plan <plan_slug> --hostname --region <region_slug> [--image <image_slug>] [--ssh-keys <ssh_key_ids>] [--ip-addresses <ip_addresses_ids>] [--os-partition-size <size>] [--userdata-file <filepath>] [--tags] [--spot-instance] [flags]
+cherryctl server create -p <project_id> --plan <plan_slug> --region <region_slug> [--hostname <hostname>] [--image <image_slug>] [--ssh-keys <ssh_key_ids>] [--ip-addresses <ip_addresses_ids>] [--os-partition-size <size>] [--userdata-file <filepath>] [--tags] [--spot-instance] [flags]
 ```
 
 ### Examples
 
 ```
   # Provisions a E5-1620v4 server in EU-Nord-1 location running on a Ubuntu 20.04:
-  cherryctl server create -p <project_id> --plan e5_1620v4 -h staging-server-1 --image ubuntu_20_04 --region eu_nord_1
+  cherryctl server create -p <project_id> --plan e5_1620v4 --hostname staging-server-1 --image ubuntu_20_04 --region eu_nord_1
 ```
 
 ### Options

--- a/internal/servers/create.go
+++ b/internal/servers/create.go
@@ -28,11 +28,11 @@ func (c *Client) Create() *cobra.Command {
 	)
 
 	createServerCmd := &cobra.Command{
-		Use:   `create -p <project_id> --plan <plan_slug> --hostname --region <region_slug> [--image <image_slug>] [--ssh-keys <ssh_key_ids>] [--ip-addresses <ip_addresses_ids>] [--os-partition-size <size>] [--userdata-file <filepath>] [--tags] [--spot-instance]`,
+		Use:   `create -p <project_id> --plan <plan_slug> --region <region_slug> [--hostname <hostname>] [--image <image_slug>] [--ssh-keys <ssh_key_ids>] [--ip-addresses <ip_addresses_ids>] [--os-partition-size <size>] [--userdata-file <filepath>] [--tags] [--spot-instance]`,
 		Short: "Create a server.",
-		Long:  "Create a server in speficied project.",
+		Long:  "Create a server in specified project.",
 		Example: `  # Provisions a E5-1620v4 server in EU-Nord-1 location running on a Ubuntu 20.04:
-  cherryctl server create -p <project_id> --plan e5_1620v4 -h staging-server-1 --image ubuntu_20_04 --region eu_nord_1`,
+  cherryctl server create -p <project_id> --plan e5_1620v4 --hostname staging-server-1 --image ubuntu_20_04 --region eu_nord_1`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true


### PR DESCRIPTION
Server creation doesn't require hostname flag to be set. Also, -h shorthand for hostname doesn't exist.
Resolves https://github.com/cherryservers/cherryctl/issues/51.