### PR TITLE
Implement API key naming policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,28 @@ cherryctl
 
 ## Table of Contents
 
-* [Introduction](#introduction)
-* [Requirements](#requirements)
-* [Supported Platforms](#supported-platforms)
-* [Installation](#installation)
-    * [Install via Homebrew](#use-homebrew-to-install-cherryctl)
-    * [Install binary from Source](#install-binary-from-source)
-    * [Install binary from Release Download](#install-binary-from-release-download)
-* [Shell Completion](#shell-completion)
-* [Authentication](#authentication)
-    * [Working With Multiple Contexts](#working-with-multiple-contexts)
-* [Configuring Default Values](#configuring-default-values)
-* [Documentation](#documentation)
-* [Examples](#examples)
+- [cherryctl](#cherryctl)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [Requirements](#requirements)
+  - [Supported Platforms](#supported-platforms)
+  - [Installation](#installation)
+    - [Install `cherryctl` Using Homebrew Package Manager](#install-cherryctl-using-homebrew-package-manager)
+    - [Install `cherryctl` from the AUR](#install-cherryctl-from-the-aur)
+    - [Install `cherryctl` from Source](#install-cherryctl-from-source)
+    - [Install a Specific `cherryctl` Release from Source](#install-a-specific-cherryctl-release-from-source)
+  - [Shell Auto-completion](#shell-auto-completion)
+  - [Authentication](#authentication)
+    - [Working With Multiple Contexts](#working-with-multiple-contexts)
+  - [Configuring Default Values](#configuring-default-values)
+  - [Documentation](#documentation)
+  - [Examples](#examples)
+    - [List Plans](#list-plans)
+    - [List Plan Images](#list-plan-images)
+    - [List Regions](#list-regions)
+    - [Deploy a New Server](#deploy-a-new-server)
+    - [List Your Servers](#list-your-servers)
+    - [Get Information About Existing Server](#get-information-about-existing-server)
 
 ## Introduction
 
@@ -32,7 +41,7 @@ with Cherry Servers platform from a command-line interface.
 
 ## Requirements
 
-* Cherry Servers authentication token.
+* Cherry Servers API key.
 * Cherry Servers CLI [binaries](https://github.com/cherryservers/cherryctl/releases).
 
 ## Supported Platforms
@@ -57,7 +66,7 @@ paru -S cherryctl
 
 ### Install `cherryctl` from Source
 
-If you have `go` 1.17 or later installed, you can build and install the latest development version with:
+If you have `go` 1.24.4 or later installed, you can build and install the latest development version with:
 
 ```sh
 go install github.com/cherryservers/cherryctl@latest
@@ -96,9 +105,9 @@ After installing Cherry Servers CLI, configure your account using `cherryctl ini
 
 ```sh
 $ cherryctl init
-Cherry Servers API Tokens can be obtained through the portal at https://portal.cherryservers.com/.
+Cherry Servers API Keys can be obtained through the portal at https://portal.cherryservers.com/settings/api-keys.
 
-Token (hidden): 
+API Key (hidden): 
 Team ID []: 12345
 Project ID []: 123456
 
@@ -108,19 +117,19 @@ Writing configuration to: /Users/username/.config/cherry/default.yaml
 This will create the `cherryctl` directory with a default context in your default OS user configuration directory. If
 you wish to store this context in a
 different location, you can pass a custom path with the `--config` option or by setting the `CHERRY_CONFIG` environment
-variable. You can also override the API token on a case-by-case basis by setting the `CHERRY_AUTH_TOKEN` environment
-variable, but a context is still required.
+variable. You can also override the API key on a case-by-case basis by setting the `CHERRY_API_KEY` environment
+variable, but a context file must still exist.
 
 ### Working With Multiple Contexts
 
 A context is a collection of settings specific to a certain user that is stored in a configuration file. It
-consists of at least an API token, a Team ID and a Project ID, but you may add many additional configuration options.
+consists of at least an API key, a Team ID and a Project ID, but you may add many additional configuration options.
 
 You may work with multiple contexts at the same time, since `cherryctl` allows you to switch between them by using
 the `--context` option. You can also switch between context directories, with the `--config` option.
 
 By default, the `--context` option has a value `default`. To create a new context, run
-`cherryctl init --context <new_context_name>`. You will be prompted for a Token, a Team ID and a Project ID which will
+`cherryctl init --context <new_context_name>`. You will be prompted for an API key, a Team ID and a Project ID which will
 be associated with the new context. You will be able to add any other options by editing the newly generated
 context file.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "dev"
+var Version string = "dev"
 
 type Cli struct {
 	MainCmd  *cobra.Command
@@ -34,7 +34,7 @@ func NewCli() *Cli {
 		Outputer: &outputs.Standard{},
 	}
 
-	rootClient := root.NewClient(version)
+	rootClient := root.NewClient(Version)
 	rootCmd := rootClient.NewCommand()
 	rootCmd.DisableSuggestions = false
 	cli.MainCmd = rootCmd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,8 +4,6 @@ Copyright © 2022 Cherry Severs <support@cherryservers.com>
 package cmd
 
 import (
-	"os"
-
 	"github.com/cherryservers/cherryctl/internal/backups"
 	root "github.com/cherryservers/cherryctl/internal/cli"
 	"github.com/cherryservers/cherryctl/internal/docs"
@@ -24,14 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	Version string = "dev"
-)
-
-const (
-	apiTokenEnvVar = "CHERRY_AUTH_TOKEN"
-	apiURL         = "https://api.cherryservers.com/v1/"
-)
+const version = "dev"
 
 type Cli struct {
 	MainCmd  *cobra.Command
@@ -43,7 +34,7 @@ func NewCli() *Cli {
 		Outputer: &outputs.Standard{},
 	}
 
-	rootClient := root.NewClient(os.Getenv(apiTokenEnvVar), apiURL, Version)
+	rootClient := root.NewClient(version)
 	rootCmd := rootClient.NewCommand()
 	rootCmd.DisableSuggestions = false
 	cli.MainCmd = rootCmd

--- a/docs/cherryctl.md
+++ b/docs/cherryctl.md
@@ -9,13 +9,13 @@ cherryctl is a command line interface (CLI) for Cherry Servers API
 ### Options
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -h, --help             help for cherryctl
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_backup.md
+++ b/docs/cherryctl_backup.md
@@ -15,12 +15,12 @@ Server backup storage operations: plans, get, list, create, update, methods, upd
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_backup_create.md
+++ b/docs/cherryctl_backup_create.md
@@ -32,12 +32,12 @@ cherryctl backup create {--server-id <id> | --server-hostname <hostname>} --plan
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_backup_delete.md
+++ b/docs/cherryctl_backup_delete.md
@@ -32,12 +32,12 @@ cherryctl backup delete ID [-f] [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_backup_get.md
+++ b/docs/cherryctl_backup_get.md
@@ -26,12 +26,12 @@ cherryctl backup get <backup_ID> [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_backup_list.md
+++ b/docs/cherryctl_backup_list.md
@@ -27,12 +27,12 @@ cherryctl backup list [-p <project_id>] [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_backup_methods-whitelist.md
+++ b/docs/cherryctl_backup_methods-whitelist.md
@@ -26,12 +26,12 @@ cherryctl backup methods-whitelist <backup_ID> [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_backup_methods.md
+++ b/docs/cherryctl_backup_methods.md
@@ -26,12 +26,12 @@ cherryctl backup methods <backup_ID> [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_backup_plans.md
+++ b/docs/cherryctl_backup_plans.md
@@ -26,12 +26,12 @@ cherryctl backup plans [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_backup_update-method.md
+++ b/docs/cherryctl_backup_update-method.md
@@ -30,12 +30,12 @@ cherryctl backup update-method <backup_ID> --method-name <string> [--enable] [--
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_backup_update.md
+++ b/docs/cherryctl_backup_update.md
@@ -31,12 +31,12 @@ cherryctl backup update <backup_ID> [--password <plain_text>] [--ssh-key <plain_
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_backup_upgrade.md
+++ b/docs/cherryctl_backup_upgrade.md
@@ -27,12 +27,12 @@ cherryctl backup upgrade <backup_ID> --plan <backup_plan_slug> [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_completion.md
+++ b/docs/cherryctl_completion.md
@@ -17,12 +17,12 @@ See each sub-command's help for details on how to use the generated script.
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_completion_bash.md
+++ b/docs/cherryctl_completion_bash.md
@@ -40,12 +40,12 @@ cherryctl completion bash
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_completion_fish.md
+++ b/docs/cherryctl_completion_fish.md
@@ -31,12 +31,12 @@ cherryctl completion fish [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_completion_powershell.md
+++ b/docs/cherryctl_completion_powershell.md
@@ -28,12 +28,12 @@ cherryctl completion powershell [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_completion_zsh.md
+++ b/docs/cherryctl_completion_zsh.md
@@ -42,12 +42,12 @@ cherryctl completion zsh [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_docs.md
+++ b/docs/cherryctl_docs.md
@@ -26,12 +26,12 @@ cherryctl docs <destination>
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_image.md
+++ b/docs/cherryctl_image.md
@@ -15,12 +15,12 @@ Image operations: list.
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_image_list.md
+++ b/docs/cherryctl_image_list.md
@@ -27,12 +27,12 @@ cherryctl image list --plan <plan_slug> [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_init.md
+++ b/docs/cherryctl_init.md
@@ -20,7 +20,7 @@ cherryctl init
 ```
   # Example config:
   --
-  token: foo
+  api-key: foo
   team-id: 123
   project-id: 123
 ```

--- a/docs/cherryctl_init.md
+++ b/docs/cherryctl_init.md
@@ -34,12 +34,12 @@ cherryctl init
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_ip.md
+++ b/docs/cherryctl_ip.md
@@ -15,12 +15,12 @@ IP address operations: get, list, create, update, assign, unassign and delete.
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_ip_assign.md
+++ b/docs/cherryctl_ip_assign.md
@@ -30,12 +30,12 @@ cherryctl ip assign ID {--target-hostname <hostname> | --target-id <server_id> |
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_ip_create.md
+++ b/docs/cherryctl_ip_create.md
@@ -34,12 +34,12 @@ cherryctl ip create -p <project_id> --region <region_slug> [--target-hostname <h
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_ip_delete.md
+++ b/docs/cherryctl_ip_delete.md
@@ -32,12 +32,12 @@ cherryctl ip delete ID [-f] [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_ip_get.md
+++ b/docs/cherryctl_ip_get.md
@@ -26,12 +26,12 @@ cherryctl ip get ID [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_ip_list.md
+++ b/docs/cherryctl_ip_list.md
@@ -28,12 +28,12 @@ cherryctl ip list -p <project_id> [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_ip_unassign.md
+++ b/docs/cherryctl_ip_unassign.md
@@ -26,12 +26,12 @@ cherryctl ip unassign ID [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_ip_update.md
+++ b/docs/cherryctl_ip_update.md
@@ -29,12 +29,12 @@ cherryctl ip update ID [--ptr-record <ptr>] [--a-record <a>] [--tags <tags>] [fl
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_plan.md
+++ b/docs/cherryctl_plan.md
@@ -15,12 +15,12 @@ Plan operations: get, list.
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_plan_list.md
+++ b/docs/cherryctl_plan_list.md
@@ -29,12 +29,12 @@ cherryctl plan list -t <team_id> [--region-id <region_slug>] [--type <type>] [fl
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_project.md
+++ b/docs/cherryctl_project.md
@@ -15,12 +15,12 @@ Project operations: get, list, create, update and delete.
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_project_create.md
+++ b/docs/cherryctl_project_create.md
@@ -29,12 +29,12 @@ cherryctl project create -t <team_id> --name <project_name> [--bgp <bool>] [flag
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_project_delete.md
+++ b/docs/cherryctl_project_delete.md
@@ -33,12 +33,12 @@ cherryctl project delete ID [-f] [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_project_get.md
+++ b/docs/cherryctl_project_get.md
@@ -27,12 +27,12 @@ cherryctl project get ID [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_project_list.md
+++ b/docs/cherryctl_project_list.md
@@ -27,12 +27,12 @@ cherryctl project list -t <team_id> [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_project_update.md
+++ b/docs/cherryctl_project_update.md
@@ -29,12 +29,12 @@ cherryctl project update ID [--name <project_name>] [--bgp <bool>] [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_region.md
+++ b/docs/cherryctl_region.md
@@ -15,12 +15,12 @@ Region operations: get, list.
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_region_get.md
+++ b/docs/cherryctl_region_get.md
@@ -26,12 +26,12 @@ cherryctl region get {ID | SLUG} [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_region_list.md
+++ b/docs/cherryctl_region_list.md
@@ -26,12 +26,12 @@ cherryctl region list [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_server.md
+++ b/docs/cherryctl_server.md
@@ -15,12 +15,12 @@ Server operations: create, get, list, delete, start, stop, reboot, reinstall, re
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_server_create.md
+++ b/docs/cherryctl_server_create.md
@@ -41,12 +41,12 @@ cherryctl server create -p <project_id> --plan <plan_slug> --region <region_slug
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_server_delete.md
+++ b/docs/cherryctl_server_delete.md
@@ -32,12 +32,12 @@ cherryctl server delete ID [-f] [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_server_enter-rescue.md
+++ b/docs/cherryctl_server_enter-rescue.md
@@ -27,12 +27,12 @@ cherryctl server enter-rescue ID --password <password> [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_server_exit-rescue.md
+++ b/docs/cherryctl_server_exit-rescue.md
@@ -26,12 +26,12 @@ cherryctl server exit-rescue ID [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_server_get.md
+++ b/docs/cherryctl_server_get.md
@@ -27,12 +27,12 @@ cherryctl server get {ID | HOSTNAME} [-p <project_id>] [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_server_list-cycles.md
+++ b/docs/cherryctl_server_list-cycles.md
@@ -26,12 +26,12 @@ cherryctl server list-cycles [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_server_list.md
+++ b/docs/cherryctl_server_list.md
@@ -28,12 +28,12 @@ cherryctl server list -p <project_id> [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_server_reboot.md
+++ b/docs/cherryctl_server_reboot.md
@@ -26,12 +26,12 @@ cherryctl server reboot ID [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_server_reinstall.md
+++ b/docs/cherryctl_server_reinstall.md
@@ -33,12 +33,12 @@ cherryctl server reinstall ID --hostname <hostname> --image <image_slug> --passw
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_server_reset-bmc-password.md
+++ b/docs/cherryctl_server_reset-bmc-password.md
@@ -28,12 +28,12 @@ cherryctl server reset-bmc-password ID [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_server_start.md
+++ b/docs/cherryctl_server_start.md
@@ -26,12 +26,12 @@ cherryctl server start ID [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_server_stop.md
+++ b/docs/cherryctl_server_stop.md
@@ -26,12 +26,12 @@ cherryctl server stop ID [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_server_update.md
+++ b/docs/cherryctl_server_update.md
@@ -30,12 +30,12 @@ cherryctl server update ID [--name <server_name>] [--hostname <hostname>] [--tag
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_server_upgrade.md
+++ b/docs/cherryctl_server_upgrade.md
@@ -27,12 +27,12 @@ cherryctl server upgrade ID --plan <plan_slug> [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_ssh-key.md
+++ b/docs/cherryctl_ssh-key.md
@@ -15,12 +15,12 @@ Ssh-key operations: get, list, update, delete.
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_ssh-key_create.md
+++ b/docs/cherryctl_ssh-key_create.md
@@ -28,12 +28,12 @@ cherryctl ssh-key create --key <public_key> --label <label> [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_ssh-key_delete.md
+++ b/docs/cherryctl_ssh-key_delete.md
@@ -33,12 +33,12 @@ cherryctl ssh-key delete -i <ssh_key_id> [-f] [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_ssh-key_get.md
+++ b/docs/cherryctl_ssh-key_get.md
@@ -26,12 +26,12 @@ cherryctl ssh-key get ID [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_ssh-key_list.md
+++ b/docs/cherryctl_ssh-key_list.md
@@ -27,12 +27,12 @@ cherryctl ssh-key list [-p <project_id>] [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_ssh-key_update.md
+++ b/docs/cherryctl_ssh-key_update.md
@@ -29,12 +29,12 @@ cherryctl ssh-key update ID [--label <text>] [--key <public_key>] [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_storage.md
+++ b/docs/cherryctl_storage.md
@@ -15,12 +15,12 @@ Storage operations: create, get, list, delete, attach and detach.
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_storage_attach.md
+++ b/docs/cherryctl_storage_attach.md
@@ -29,12 +29,12 @@ cherryctl storage attach ID {--server-id <id> | --server-hostname <hostname>} [-
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_storage_create.md
+++ b/docs/cherryctl_storage_create.md
@@ -30,12 +30,12 @@ cherryctl storage create -p <project_id> --size <gigabytes> --region <region_slu
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_storage_delete.md
+++ b/docs/cherryctl_storage_delete.md
@@ -32,12 +32,12 @@ cherryctl storage delete ID [f] [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_storage_detach.md
+++ b/docs/cherryctl_storage_detach.md
@@ -26,12 +26,12 @@ cherryctl storage detach ID [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_storage_get.md
+++ b/docs/cherryctl_storage_get.md
@@ -26,12 +26,12 @@ cherryctl storage get ID [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_storage_list.md
+++ b/docs/cherryctl_storage_list.md
@@ -27,12 +27,12 @@ cherryctl storage list -p <project_id> [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_storage_update.md
+++ b/docs/cherryctl_storage_update.md
@@ -28,12 +28,12 @@ cherryctl storage update ID [--size <gigabytes>] [--description <text>] [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_team.md
+++ b/docs/cherryctl_team.md
@@ -15,12 +15,12 @@ Team operations: get, list.
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_team_create.md
+++ b/docs/cherryctl_team_create.md
@@ -29,12 +29,12 @@ cherryctl team create --name <team_name> --type <team_type> [--currency <currenc
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_team_delete.md
+++ b/docs/cherryctl_team_delete.md
@@ -33,12 +33,12 @@ cherryctl team delete ID [f] [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_team_get.md
+++ b/docs/cherryctl_team_get.md
@@ -27,12 +27,12 @@ cherryctl team get ID [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_team_list.md
+++ b/docs/cherryctl_team_list.md
@@ -26,12 +26,12 @@ cherryctl team list [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_team_update.md
+++ b/docs/cherryctl_team_update.md
@@ -30,12 +30,12 @@ cherryctl team update ID [--name <team_name>] [--currency <currency_code>] [--ty
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_user.md
+++ b/docs/cherryctl_user.md
@@ -15,12 +15,12 @@ User operations: get.
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/docs/cherryctl_user_get.md
+++ b/docs/cherryctl_user_get.md
@@ -29,12 +29,12 @@ cherryctl user get ID [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string   API key. Can be created at https://portal.cherryservers.com/settings/api-keys.
       --api-url string   Override default API endpoint (default "https://api.cherryservers.com/v1/")
       --config string    Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.
       --context string   Specify a custom context name (default "default")
       --fields strings   Comma separated object field names to output in result. Fields can be used for list and get actions.
   -o, --output string    Output format (*table, json, yaml)
-      --token string     API Token (CHERRY_AUTH_TOKEN)
 ```
 
 ### SEE ALSO

--- a/integration/testdata/get_usr.json
+++ b/integration/testdata/get_usr.json
@@ -1,0 +1,21 @@
+{
+  "id": 123456,
+  "first_name": "",
+  "last_name": "",
+  "email": "john.doe@cherryservers.com",
+  "email_verified": false,
+  "phone": "",
+  "security_phone_verified": false,
+  "state": "",
+  "city": "",
+  "country_iso_2": "LT",
+  "href": "/users/123456",
+  "security_phone": "",
+  "skype_username": "",
+  "linkedin_profile": "",
+  "address_1": "",
+  "address_2": "",
+  "date_of_birth": "",
+  "national_id_number": "",
+  "created": "2025-11-01T015:53:22+00:00"
+}

--- a/integration/token_test.go
+++ b/integration/token_test.go
@@ -57,7 +57,7 @@ func tempFileWithContent(t *testing.T, name, content string) *os.File {
 
 func TestAuthConfigHierarchy(t *testing.T) {
 	const (
-		tokenVar = "CHERRY_AUTH_TOKEN"
+		tokenVar  = "CHERRY_AUTH_TOKEN"
 		apiKeyVar = "CHERRY_API_KEY"
 	)
 

--- a/integration/token_test.go
+++ b/integration/token_test.go
@@ -56,7 +56,11 @@ func tempFileWithContent(t *testing.T, name, content string) *os.File {
 }
 
 func TestTokenConfigHierarchy(t *testing.T) {
-	const tokenVar = "CHERRY_AUTH_TOKEN"
+	const (
+		tokenVar = "CHERRY_AUTH_TOKEN"
+		apiKeyVar = "CHERRY_API_KEY"
+	)
+
 	t.Run("set via env var", func(t *testing.T) {
 		testTokenConfigHierarchy(t, func(_ *cmd.Cli) {
 			t.Setenv(tokenVar, "abc")
@@ -69,7 +73,7 @@ func TestTokenConfigHierarchy(t *testing.T) {
 		})
 	})
 
-	t.Run("set via auth_token flag", func(t *testing.T) {
+	t.Run("set via auth-token flag", func(t *testing.T) {
 		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
 			cli.MainCmd.PersistentFlags().Set("auth-token", "abc")
 		})
@@ -109,7 +113,7 @@ func TestTokenConfigHierarchy(t *testing.T) {
 	// This happens because CHERRY_AUTH_TOKEN and auth-token
 	// configure the same viper value, but viper prioritizes CLI
 	// flags over env variables.
-	t.Run("auth token flag beats env var", func(t *testing.T) {
+	t.Run("auth-token flag beats env var", func(t *testing.T) {
 		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
 			cli.MainCmd.PersistentFlags().Set("auth-token", "abc")
 			t.Setenv(tokenVar, "bad")
@@ -122,6 +126,44 @@ func TestTokenConfigHierarchy(t *testing.T) {
 		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
 			cli.MainCmd.PersistentFlags().Set("config", filepath.Dir(cfg.Name()))
 			cli.MainCmd.PersistentFlags().Set("token", "abc")
+		})
+	})
+	t.Run("api-key flag beats other flags", func(t *testing.T) {
+		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+			cli.MainCmd.PersistentFlags().Set("api-key", "abc")
+			cli.MainCmd.PersistentFlags().Set("token", "bad")
+			cli.MainCmd.PersistentFlags().Set("auth-token", "bad")
+		})
+	})
+
+	t.Run("api-key flag beats env var", func(t *testing.T) {
+		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+			t.Setenv(apiKeyVar, "bad")
+			cli.MainCmd.PersistentFlags().Set("api-key", "abc")
+		})
+	})
+
+	t.Run("api-key env var beats auth-token env var", func(t *testing.T) {
+		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+			t.Setenv(tokenVar, "bad")
+			t.Setenv(apiKeyVar, "abc")
+		})
+	})
+
+	t.Run("api-key env var beats config file", func(t *testing.T) {
+		cfg := tempFileWithContent(t, "default.yaml", "token: bad\n")
+
+		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+			t.Setenv(apiKeyVar, "abc")
+			cli.MainCmd.PersistentFlags().Set("config", filepath.Dir(cfg.Name()))
+		})
+	})
+
+	t.Run("api-key config file beats other in-file configs", func(t *testing.T) {
+		cfg := tempFileWithContent(t, "default.yaml", "token: bad\nauth-token: bad\napi-key: abc\n")
+
+		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+			cli.MainCmd.PersistentFlags().Set("config", filepath.Dir(cfg.Name()))
 		})
 	})
 }

--- a/integration/token_test.go
+++ b/integration/token_test.go
@@ -1,0 +1,162 @@
+package integration
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cherryservers/cherryctl/cmd"
+)
+
+func discardStdout(t *testing.T) {
+	t.Helper()
+
+	nullOut, err := os.OpenFile(os.DevNull, os.O_WRONLY, os.ModeDevice)
+	if err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+
+	old := os.Stdout
+	os.Stdout = nullOut
+
+	t.Cleanup(func() {
+		os.Stdout = old
+		if err := nullOut.Close(); err != nil {
+			t.Errorf("failed to close dev null file: %s", err.Error())
+		}
+	})
+}
+
+func tempFileWithContent(t *testing.T, name, content string) *os.File {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	temp, err := os.Create(filepath.Join(dir, name))
+	if err != nil {
+		t.Fatalf("failed to create temp file: %s", err.Error())
+	}
+	t.Cleanup(func() {
+		if err = temp.Close(); err != nil {
+			t.Errorf("failed to close temp file: %s", err.Error())
+		}
+		if err = os.Remove(temp.Name()); err != nil {
+			t.Errorf("failed to remove temp file: %s", err.Error())
+		}
+	})
+	if _, err = fmt.Fprint(temp, content); err != nil {
+		t.Fatalf("failed to write to temp file: %s", err.Error())
+	}
+
+	return temp
+}
+
+func TestTokenConfigHierarchy(t *testing.T) {
+	const tokenVar = "CHERRY_AUTH_TOKEN"
+	t.Run("set via env var", func(t *testing.T) {
+		testTokenConfigHierarchy(t, func(_ *cmd.Cli) {
+			t.Setenv(tokenVar, "abc")
+		})
+	})
+
+	t.Run("set via token flag", func(t *testing.T) {
+		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+			cli.MainCmd.PersistentFlags().Set("token", "abc")
+		})
+	})
+
+	t.Run("set via auth_token flag", func(t *testing.T) {
+		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+			cli.MainCmd.PersistentFlags().Set("auth-token", "abc")
+		})
+	})
+
+	t.Run("auth-token flag beats token flag", func(t *testing.T) {
+		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+			cli.MainCmd.PersistentFlags().Set("token", "bad")
+			cli.MainCmd.PersistentFlags().Set("auth-token", "abc")
+		})
+	})
+
+	t.Run("set via default config context file", func(t *testing.T) {
+		cfg := tempFileWithContent(t, "default.yaml", "token: abc\n")
+
+		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+			cli.MainCmd.PersistentFlags().Set("config", filepath.Dir(cfg.Name()))
+		})
+	})
+
+	t.Run("set via custom config context file", func(t *testing.T) {
+		cfg := tempFileWithContent(t, "custom.yaml", "token: abc\n")
+
+		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+			cli.MainCmd.PersistentFlags().Set("config", filepath.Dir(cfg.Name()))
+			cli.MainCmd.PersistentFlags().Set("context", "custom")
+		})
+	})
+
+	t.Run("env var beats token flag", func(t *testing.T) {
+		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+			t.Setenv(tokenVar, "abc")
+			cli.MainCmd.PersistentFlags().Set("token", "bad")
+		})
+	})
+
+	// This happens because CHERRY_AUTH_TOKEN and auth-token
+	// configure the same viper value, but viper prioritizes CLI
+	// flags over env variables.
+	t.Run("auth token flag beats env var", func(t *testing.T) {
+		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+			cli.MainCmd.PersistentFlags().Set("auth-token", "abc")
+			t.Setenv(tokenVar, "bad")
+		})
+	})
+
+	t.Run("token flag beats config file", func(t *testing.T) {
+		cfg := tempFileWithContent(t, "default.yaml", "token: bad\n")
+
+		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+			cli.MainCmd.PersistentFlags().Set("config", filepath.Dir(cfg.Name()))
+			cli.MainCmd.PersistentFlags().Set("token", "abc")
+		})
+	})
+}
+
+func testTokenConfigHierarchy(t *testing.T, preExecute func(cli *cmd.Cli)) {
+	cli := cmd.NewCli()
+	discardStdout(t)
+
+	mux := http.NewServeMux()
+	svc := httptest.NewServer(mux)
+	defer svc.Close()
+
+	respBodyFile, err := os.Open(filepath.Join("testdata", "get_usr.json"))
+	if err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+	defer respBodyFile.Close()
+
+	mux.HandleFunc("GET /v1/user", func(w http.ResponseWriter, r *http.Request) {
+		got := r.Header.Get("Authorization")
+		if got != "Bearer abc" {
+			t.Errorf("want token %q, got: %q", "abc", got)
+		}
+		_, err := io.Copy(w, respBodyFile)
+		if err != nil {
+			t.Errorf("failed to write api response: %s", err)
+		}
+	})
+
+	cli.MainCmd.SetArgs([]string{"user", "get"})
+	cli.MainCmd.PersistentFlags().Set("api-url", svc.URL)
+
+	preExecute(cli)
+
+	if err := cli.MainCmd.Execute(); err != nil {
+		t.Fatalf("failed to execute command: %s", err.Error())
+	}
+}

--- a/integration/token_test.go
+++ b/integration/token_test.go
@@ -61,6 +61,11 @@ func TestTokenConfigHierarchy(t *testing.T) {
 		apiKeyVar = "CHERRY_API_KEY"
 	)
 
+	// If no config directory is set, cherryctl will try to fallback
+	// to some default directory, potentially interfering with test results.
+	defaultConfig := tempFileWithContent(t, "default.yaml", "")
+	t.Setenv("CHERRY_CONFIG", filepath.Dir(defaultConfig.Name()))
+
 	t.Run("set via env var", func(t *testing.T) {
 		testTokenConfigHierarchy(t, func(_ *cmd.Cli) {
 			t.Setenv(tokenVar, "abc")

--- a/integration/token_test.go
+++ b/integration/token_test.go
@@ -55,7 +55,7 @@ func tempFileWithContent(t *testing.T, name, content string) *os.File {
 	return temp
 }
 
-func TestTokenConfigHierarchy(t *testing.T) {
+func TestAuthConfigHierarchy(t *testing.T) {
 	const (
 		tokenVar = "CHERRY_AUTH_TOKEN"
 		apiKeyVar = "CHERRY_API_KEY"
@@ -67,25 +67,25 @@ func TestTokenConfigHierarchy(t *testing.T) {
 	t.Setenv("CHERRY_CONFIG", filepath.Dir(defaultConfig.Name()))
 
 	t.Run("set via env var", func(t *testing.T) {
-		testTokenConfigHierarchy(t, func(_ *cmd.Cli) {
+		testAuthConfigHierarchy(t, func(_ *cmd.Cli) {
 			t.Setenv(tokenVar, "abc")
 		})
 	})
 
 	t.Run("set via token flag", func(t *testing.T) {
-		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+		testAuthConfigHierarchy(t, func(cli *cmd.Cli) {
 			cli.MainCmd.PersistentFlags().Set("token", "abc")
 		})
 	})
 
 	t.Run("set via auth-token flag", func(t *testing.T) {
-		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+		testAuthConfigHierarchy(t, func(cli *cmd.Cli) {
 			cli.MainCmd.PersistentFlags().Set("auth-token", "abc")
 		})
 	})
 
 	t.Run("auth-token flag beats token flag", func(t *testing.T) {
-		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+		testAuthConfigHierarchy(t, func(cli *cmd.Cli) {
 			cli.MainCmd.PersistentFlags().Set("token", "bad")
 			cli.MainCmd.PersistentFlags().Set("auth-token", "abc")
 		})
@@ -94,7 +94,7 @@ func TestTokenConfigHierarchy(t *testing.T) {
 	t.Run("set via default config context file", func(t *testing.T) {
 		cfg := tempFileWithContent(t, "default.yaml", "token: abc\n")
 
-		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+		testAuthConfigHierarchy(t, func(cli *cmd.Cli) {
 			cli.MainCmd.PersistentFlags().Set("config", filepath.Dir(cfg.Name()))
 		})
 	})
@@ -102,14 +102,14 @@ func TestTokenConfigHierarchy(t *testing.T) {
 	t.Run("set via custom config context file", func(t *testing.T) {
 		cfg := tempFileWithContent(t, "custom.yaml", "token: abc\n")
 
-		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+		testAuthConfigHierarchy(t, func(cli *cmd.Cli) {
 			cli.MainCmd.PersistentFlags().Set("config", filepath.Dir(cfg.Name()))
 			cli.MainCmd.PersistentFlags().Set("context", "custom")
 		})
 	})
 
 	t.Run("env var beats token flag", func(t *testing.T) {
-		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+		testAuthConfigHierarchy(t, func(cli *cmd.Cli) {
 			t.Setenv(tokenVar, "abc")
 			cli.MainCmd.PersistentFlags().Set("token", "bad")
 		})
@@ -119,7 +119,7 @@ func TestTokenConfigHierarchy(t *testing.T) {
 	// configure the same viper value, but viper prioritizes CLI
 	// flags over env variables.
 	t.Run("auth-token flag beats env var", func(t *testing.T) {
-		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+		testAuthConfigHierarchy(t, func(cli *cmd.Cli) {
 			cli.MainCmd.PersistentFlags().Set("auth-token", "abc")
 			t.Setenv(tokenVar, "bad")
 		})
@@ -128,13 +128,13 @@ func TestTokenConfigHierarchy(t *testing.T) {
 	t.Run("token flag beats config file", func(t *testing.T) {
 		cfg := tempFileWithContent(t, "default.yaml", "token: bad\n")
 
-		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+		testAuthConfigHierarchy(t, func(cli *cmd.Cli) {
 			cli.MainCmd.PersistentFlags().Set("config", filepath.Dir(cfg.Name()))
 			cli.MainCmd.PersistentFlags().Set("token", "abc")
 		})
 	})
 	t.Run("api-key flag beats other flags", func(t *testing.T) {
-		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+		testAuthConfigHierarchy(t, func(cli *cmd.Cli) {
 			cli.MainCmd.PersistentFlags().Set("api-key", "abc")
 			cli.MainCmd.PersistentFlags().Set("token", "bad")
 			cli.MainCmd.PersistentFlags().Set("auth-token", "bad")
@@ -142,14 +142,14 @@ func TestTokenConfigHierarchy(t *testing.T) {
 	})
 
 	t.Run("api-key flag beats env var", func(t *testing.T) {
-		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+		testAuthConfigHierarchy(t, func(cli *cmd.Cli) {
 			t.Setenv(apiKeyVar, "bad")
 			cli.MainCmd.PersistentFlags().Set("api-key", "abc")
 		})
 	})
 
 	t.Run("api-key env var beats auth-token env var", func(t *testing.T) {
-		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+		testAuthConfigHierarchy(t, func(cli *cmd.Cli) {
 			t.Setenv(tokenVar, "bad")
 			t.Setenv(apiKeyVar, "abc")
 		})
@@ -158,7 +158,7 @@ func TestTokenConfigHierarchy(t *testing.T) {
 	t.Run("api-key env var beats config file", func(t *testing.T) {
 		cfg := tempFileWithContent(t, "default.yaml", "token: bad\n")
 
-		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+		testAuthConfigHierarchy(t, func(cli *cmd.Cli) {
 			t.Setenv(apiKeyVar, "abc")
 			cli.MainCmd.PersistentFlags().Set("config", filepath.Dir(cfg.Name()))
 		})
@@ -167,13 +167,13 @@ func TestTokenConfigHierarchy(t *testing.T) {
 	t.Run("api-key config file beats other in-file configs", func(t *testing.T) {
 		cfg := tempFileWithContent(t, "default.yaml", "token: bad\nauth-token: bad\napi-key: abc\n")
 
-		testTokenConfigHierarchy(t, func(cli *cmd.Cli) {
+		testAuthConfigHierarchy(t, func(cli *cmd.Cli) {
 			cli.MainCmd.PersistentFlags().Set("config", filepath.Dir(cfg.Name()))
 		})
 	})
 }
 
-func testTokenConfigHierarchy(t *testing.T, preExecute func(cli *cmd.Cli)) {
+func testAuthConfigHierarchy(t *testing.T, preExecute func(cli *cmd.Cli)) {
 	cli := cmd.NewCli()
 	discardStdout(t)
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -33,15 +33,15 @@ type Client struct {
 	configPath   string
 	context      string
 	outputFormat string
-	cherryToken  string
+	apiKey  string
 	apiURL       string
 	Version      string
 	rootCmd      *cobra.Command
 	viper        *viper.Viper
 }
 
-func (c *Client) SetToken(token string) {
-	c.cherryToken = token
+func (c *Client) SetAPIKey(apiKey string) {
+	c.apiKey = apiKey
 }
 
 func NewClient(version string) *Client {
@@ -49,12 +49,12 @@ func NewClient(version string) *Client {
 }
 
 func (c *Client) API(cmd *cobra.Command) *cherrygo.Client {
-	if c.cherryToken == "" {
-		log.Fatal("Cherry Servers API authentication token not provided. Please set the 'CHERRY_AUTH_TOKEN' environment variable or create a configuration file using 'cherryctl init'.")
+	if c.apiKey == "" {
+		log.Fatal("Cherry Servers API key not provided. Please set the 'CHERRY_API_KEY' environment variable or create a configuration file using 'cherryctl init'.")
 	}
 
 	if c.apiClient == nil {
-		args := []cherrygo.ClientOpt{cherrygo.WithAuthToken(c.cherryToken), cherrygo.WithUserAgent("cherry-cli/" + c.Version)}
+		args := []cherrygo.ClientOpt{cherrygo.WithAuthToken(c.apiKey), cherrygo.WithUserAgent("cherry-cli/" + c.Version)}
 
 		if c.apiURL != "" {
 			args = append(args, cherrygo.WithURL(c.apiURL))
@@ -178,12 +178,12 @@ func (c *Client) Config(cmd *cobra.Command) *viper.Viper {
 		flagToken := cmd.Flag("token").Value.String()
 		envToken := cmd.Flag("auth-token").Value.String()
 		apiKey := cmd.Flag("api-key").Value.String()
-		c.cherryToken = flagToken
+		c.apiKey = flagToken
 		if envToken != "" {
-			c.cherryToken = envToken
+			c.apiKey = envToken
 		}
 		if apiKey != "" {
-			c.cherryToken = apiKey
+			c.apiKey = apiKey
 		}
 
 		return c.viper

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -102,10 +102,20 @@ func (c *Client) NewCommand() *cobra.Command {
 			c.Config(cmd)
 		},
 	}
+	rootCmd.PersistentFlags().String("api-key", "", "API key. Can be created at https://portal.cherryservers.com/settings/api-keys.")
+
+	// Flags deprecated in favor of `api-key`, see https://github.com/cherryservers/cherryctl/issues/73.
 	rootCmd.PersistentFlags().String("token", "", "API Token (CHERRY_AUTH_TOKEN)")
 	rootCmd.PersistentFlags().String("auth-token", "", "API Token (Alias)")
-	authtoken := rootCmd.PersistentFlags().Lookup("auth-token")
-	authtoken.Hidden = true
+
+	// Would be nice to add a mutual exclusivity constraint as well,
+	// but that breaks existing setups such as:
+	//
+	// `token` is defined in a config file AND `CHERRY_AUTH_TOKEN` is set.
+	// 
+	// This will result in an error, because viper merges config sources.
+	rootCmd.PersistentFlags().MarkDeprecated("token", "use '--api-key' instead.")
+	rootCmd.PersistentFlags().MarkDeprecated("auth-token", "use '--api-key' instead.")
 
 	rootCmd.PersistentFlags().StringVar(&c.configPath, "config", "", "Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.")
 	rootCmd.PersistentFlags().StringVar(&c.context, "context", DefaultContext, "Specify a custom context name")
@@ -166,11 +176,17 @@ func (c *Client) Config(cmd *cobra.Command) *viper.Viper {
 			bindFlags(cmd, v)
 		}
 
+		// api-key is the canonical flag, with the other two being deprecated,
+		// so it should beat them.
 		flagToken := cmd.Flag("token").Value.String()
 		envToken := cmd.Flag("auth-token").Value.String()
+		apiKey := cmd.Flag("api-key").Value.String()
 		c.cherryToken = flagToken
 		if envToken != "" {
 			c.cherryToken = envToken
+		}
+		if apiKey != "" {
+			c.cherryToken = apiKey
 		}
 
 		return c.viper

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -22,6 +22,7 @@ const (
 	DefaultConfigDirName = "cherryctl"
 	OldDefaultContext    = "cherry"
 	OldConfigPathSuffix  = "/.config/cherry"
+	DefaultBaseURL       = "https://api.cherryservers.com/v1/"
 )
 
 type Client struct {
@@ -43,12 +44,8 @@ func (c *Client) SetToken(token string) {
 	c.cherryToken = token
 }
 
-func NewClient(cherryToken, apiURL, Version string) *Client {
-	return &Client{
-		cherryToken: cherryToken,
-		apiURL:      apiURL,
-		Version:     Version,
-	}
+func NewClient(version string) *Client {
+	return &Client{Version: version}
 }
 
 func (c *Client) API(cmd *cobra.Command) *cherrygo.Client {
@@ -112,14 +109,14 @@ func (c *Client) NewCommand() *cobra.Command {
 	// but that breaks existing setups such as:
 	//
 	// `token` is defined in a config file AND `CHERRY_AUTH_TOKEN` is set.
-	// 
+	//
 	// This will result in an error, because viper merges config sources.
 	rootCmd.PersistentFlags().MarkDeprecated("token", "use '--api-key' instead.")
 	rootCmd.PersistentFlags().MarkDeprecated("auth-token", "use '--api-key' instead.")
 
 	rootCmd.PersistentFlags().StringVar(&c.configPath, "config", "", "Path to configuration file directory. The CHERRY_CONFIG environment variable can be used as well.")
 	rootCmd.PersistentFlags().StringVar(&c.context, "context", DefaultContext, "Specify a custom context name")
-	rootCmd.PersistentFlags().StringVar(&c.apiURL, "api-url", c.apiURL, "Override default API endpoint")
+	rootCmd.PersistentFlags().StringVar(&c.apiURL, "api-url", DefaultBaseURL, "Override default API endpoint")
 	rootCmd.PersistentFlags().StringVarP(&c.outputFormat, "output", "o", "", "Output format (*table, json, yaml)")
 	c.fields = rootCmd.PersistentFlags().StringSlice("fields", nil, "Comma separated object field names to output in result. Fields can be used for list and get actions.")
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -33,7 +33,7 @@ type Client struct {
 	configPath   string
 	context      string
 	outputFormat string
-	apiKey  string
+	apiKey       string
 	apiURL       string
 	Version      string
 	rootCmd      *cobra.Command

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -29,7 +29,7 @@ func NewClient(s Servicer) *Client {
 }
 
 type configFormat struct {
-	Token     string `yaml:"token,omitempty"`
+	APIKey    string `yaml:"api-key,omitempty"`
 	ProjectID int    `yaml:"project-id,omitempty"`
 	TeamID    int    `yaml:"team-id,omitempty"`
 }
@@ -37,8 +37,6 @@ type configFormat struct {
 func (c *Client) NewCommand() *cobra.Command {
 	// initCmd represents a command that, when run, generates a
 	// set of initironment variables, for use in shell initironments
-	// v := c.tokener.Config()
-	// projectId := v.GetString("project-id")
 	initCmd := &cobra.Command{
 		Use:   `init`,
 		Short: "Configuration file initialization.",
@@ -51,7 +49,7 @@ The configuration directory path can be changed with the CHERRY_CONFIG environme
 
 		Example: `  # Example config:
   --
-  token: foo
+  api-key: foo
   team-id: 123
   project-id: 123`,
 
@@ -82,11 +80,11 @@ The configuration directory path can be changed with the CHERRY_CONFIG environme
 				return err
 			}
 
-			token, err := c.readAPIToken()
+			apiKey, err := c.readAPIKey()
 			if err != nil {
 				return err
 			}
-			if err = c.validateToken(cmd); err != nil {
+			if err = c.validateAPIKey(cmd); err != nil {
 				return err
 			}
 
@@ -102,7 +100,7 @@ The configuration directory path can be changed with the CHERRY_CONFIG environme
 				return err
 			}
 
-			b, err := formatConfig(userProj, userTeam, token)
+			b, err := formatConfig(userProj, userTeam, apiKey)
 			if err != nil {
 				return err
 			}
@@ -119,26 +117,26 @@ The configuration directory path can be changed with the CHERRY_CONFIG environme
 	return initCmd
 }
 
-func (c *Client) readAPIToken() (string, error) {
-	fmt.Print("Cherry Servers API Tokens can be obtained through the portal at http://portal.cherryservers.com/.\n\n")
-	fmt.Print("Token (hidden): ")
+func (c *Client) readAPIKey() (string, error) {
+	fmt.Print("Cherry Servers API Keys can be obtained through the portal at https://portal.cherryservers.com/settings/api-keys.\n\n")
+	fmt.Print("API key (hidden): ")
 	b, err := term.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		return string(b), err
 	}
 	fmt.Println()
-	token := string(b)
-	c.Servicer.SetToken(token)
+	apiKey := string(b)
+	c.Servicer.SetToken(apiKey)
 
-	return token, nil
+	return apiKey, nil
 }
 
-func (c *Client) validateToken(cmd *cobra.Command) error {
+func (c *Client) validateAPIKey(cmd *cobra.Command) error {
 	cherryClient := c.Servicer.API(cmd)
 	c.UserService = cherryClient.Users
 	_, _, err := c.UserService.CurrentUser(nil)
 	if err != nil {
-		return errors.Wrap(err, "Invalid authentication token")
+		return errors.Wrap(err, "Invalid API key")
 	}
 	return nil
 }
@@ -191,10 +189,10 @@ func (c *Client) readUserProject(cherryClient *cherrygo.Client, userTeam string)
 	return userProj, nil
 }
 
-func formatConfig(userProj, userTeam, token string) ([]byte, error) {
+func formatConfig(userProj, userTeam, apiKey string) ([]byte, error) {
 	userProjInt, _ := strconv.Atoi(userProj)
 	userTeamInt, _ := strconv.Atoi(userTeam)
-	f := configFormat{ProjectID: userProjInt, TeamID: userTeamInt, Token: token}
+	f := configFormat{ProjectID: userProjInt, TeamID: userTeamInt, APIKey: apiKey}
 	b, err := yaml.Marshal(f)
 
 	if err != nil {

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -126,7 +126,7 @@ func (c *Client) readAPIKey() (string, error) {
 	}
 	fmt.Println()
 	apiKey := string(b)
-	c.Servicer.SetToken(apiKey)
+	c.Servicer.SetAPIKey(apiKey)
 
 	return apiKey, nil
 }
@@ -219,7 +219,7 @@ func (c *Client) checkAndCreateConfigDir(configDir string) error {
 
 type Servicer interface {
 	API(*cobra.Command) *cherrygo.Client
-	SetToken(string)
+	SetAPIKey(string)
 }
 
 var _ Servicer = (*cli.Client)(nil)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2022 Cherry Severs <support@cherryservers.com>
-
 */
 package main
 


### PR DESCRIPTION
Adds an `api-key` flag with an equivalent environment variable and file configuration option, while deprecating `token` and `auth-token`. Also, removes all references to said tokens from documentation, code and the `init` command. Integration tests are provided to ensure the old configuration options still work, but the new ones beat them.

Perhaps the only slightly counter-intuitive configuration scenario is when the new `api-key` is used in combination with the old `token` at what would typically be a higher precedence configuration layer, i.e. `api-key` is set in the config file and `token` is set a as a CLI flag. In that case, the config file will beat the CLI flag. This happens because `viper` aggregates configuration sources and has it's pre-defined hierarchy for them. Since this seems like a fairly niche scenario, I decided to leave it as is, but am open to changing this as well.

Closes https://github.com/cherryservers/cherryctl/issues/73.