### PR TITLE
Add plan tests

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cherryservers/cherryctl/internal/storages"
 	"github.com/cherryservers/cherryctl/internal/teams"
 	"github.com/cherryservers/cherryctl/internal/users"
+	"github.com/cherryservers/cherrygo/v3"
 	"github.com/spf13/cobra"
 )
 
@@ -58,6 +59,25 @@ func NewCli() *Cli {
 	return cli
 }
 
+type planDeps struct {
+	client *root.Client
+	out    outputs.Outputer
+}
+
+func (d *planDeps) Client() cherrygo.PlansService {
+	// The API method doesn't actually use the command for anything, so we can pass nil.
+	// Should refactor it out at some point.
+	return d.client.API(nil).Plans
+}
+
+func (d *planDeps) GetOpts() *cherrygo.GetOptions {
+	return d.client.GetOptions()
+}
+
+func (d *planDeps) Outputer() outputs.Outputer {
+	return d.out
+}
+
 func (cli *Cli) RegisterCommands(client *root.Client) {
 	cli.MainCmd.AddCommand(
 		docs.NewCommand(),
@@ -68,7 +88,9 @@ func (cli *Cli) RegisterCommands(client *root.Client) {
 		storages.NewClient(client, cli.Outputer).NewCommand(),
 		backups.NewClient(client, cli.Outputer).NewCommand(),
 		regions.NewClient(client, cli.Outputer).NewCommand(),
-		plans.NewClient(client, cli.Outputer).NewCommand(),
+		// We don't have the dependencies initialized yet, as that's done
+		// on pre-execution, so we need an injector interface.
+		plans.NewCommand(&planDeps{client: client, out: cli.Outputer}).CobraCommand(),
 		projects.NewClient(client, cli.Outputer).NewCommand(),
 		teams.NewClient(client, cli.Outputer).NewCommand(),
 		sshkeys.NewClient(client, cli.Outputer).NewCommand(),

--- a/docs/cherryctl_plan_list.md
+++ b/docs/cherryctl_plan_list.md
@@ -23,7 +23,7 @@ cherryctl plan list -t <team_id> [--region-id <region_slug>] [--type <type>] [fl
   -h, --help            help for list
   -r, --region string   The Slug or ID of region.
   -t, --team-id int     The team's ID. Return plans prices based on team billing details.
-      --type strings    Comma separated list of available plan types (baremetal,virtual,vps)
+      --type strings    Comma separated list of available plan types.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cherryctl_plan_list.md
+++ b/docs/cherryctl_plan_list.md
@@ -7,7 +7,7 @@ Retrieves a list of server plans.
 Retrieves a list of server plans with their corresponding hourly rates and stock volumes.
 
 ```
-cherryctl plan list -t <team_id> [--region-id <region_slug>] [--type <type>] [flags]
+cherryctl plan list -t <team_id> [--region <region_slug>] [--type <type>] [flags]
 ```
 
 ### Examples

--- a/internal/fakes/output.go
+++ b/internal/fakes/output.go
@@ -1,0 +1,16 @@
+package fakes
+
+import "github.com/cherryservers/cherryctl/internal/outputs"
+
+type Outputer struct {
+	Calls []OutputRecord
+}
+
+func (o *Outputer) Output(in any, th []string, td *[][]string) error {
+	o.Calls = append(o.Calls, OutputRecord{in: in, th: th, td: *td})
+	return nil
+}
+
+func (o *Outputer) SetFormat(outputs.Format) {
+
+}

--- a/internal/fakes/plan.go
+++ b/internal/fakes/plan.go
@@ -1,0 +1,47 @@
+package fakes
+
+import (
+	"errors"
+
+	"github.com/cherryservers/cherrygo/v3"
+)
+
+type PlanService struct {
+	Calls []CallRecord
+}
+
+func (s *PlanService) List(teamID int, opts *cherrygo.GetOptions) ([]cherrygo.Plan, *cherrygo.Response, error) {
+	s.Calls = append(s.Calls, CallRecord{method: "List", params: []any{teamID, opts}})
+	return []cherrygo.Plan{s.Plan()}, nil, nil
+}
+
+func (s *PlanService) GetBySlug(slug string, opts *cherrygo.GetOptions) (cherrygo.Plan, *cherrygo.Response, error) {
+	s.Calls = append(s.Calls, CallRecord{method: "GetBySlug", params: []any{slug, opts}})
+	return s.Plan(), nil, nil
+}
+
+func (s *PlanService) GetByID(_ int, _ *cherrygo.GetOptions) (cherrygo.Plan, *cherrygo.Response, error) {
+	return cherrygo.Plan{}, nil, errors.New("not implemented")
+}
+
+// Plan is the plan that will be returned by the fake methods.
+func (s *PlanService) Plan() cherrygo.Plan {
+	pricing := []cherrygo.Pricing{
+		{
+			Unit:  "Hourly",
+			Price: 1.0,
+		},
+		{
+			Unit:  "Spot hourly",
+			Price: 0.5,
+		},
+	}
+	regions := []cherrygo.AvailableRegions{
+		{
+			Region:   &cherrygo.Region{Slug: "test-slug"},
+			StockQty: 1,
+			SpotQty:  2,
+		},
+	}
+	return cherrygo.Plan{ID: 1, Slug: "test-slug", Pricing: pricing, AvailableRegions: regions}
+}

--- a/internal/fakes/plan.go
+++ b/internal/fakes/plan.go
@@ -38,7 +38,7 @@ func (s *PlanService) Plan() cherrygo.Plan {
 	}
 	regions := []cherrygo.AvailableRegions{
 		{
-			Region:   &cherrygo.Region{ID:1, Slug: "test-region"},
+			Region:   &cherrygo.Region{ID: 1, Slug: "test-region"},
 			StockQty: 1,
 			SpotQty:  2,
 		},

--- a/internal/fakes/plan.go
+++ b/internal/fakes/plan.go
@@ -38,10 +38,10 @@ func (s *PlanService) Plan() cherrygo.Plan {
 	}
 	regions := []cherrygo.AvailableRegions{
 		{
-			Region:   &cherrygo.Region{Slug: "test-slug"},
+			Region:   &cherrygo.Region{ID:1, Slug: "test-region"},
 			StockQty: 1,
 			SpotQty:  2,
 		},
 	}
-	return cherrygo.Plan{ID: 1, Slug: "test-slug", Pricing: pricing, AvailableRegions: regions}
+	return cherrygo.Plan{ID: 1, Slug: "test-plan", Pricing: pricing, AvailableRegions: regions}
 }

--- a/internal/fakes/record.go
+++ b/internal/fakes/record.go
@@ -1,0 +1,60 @@
+package fakes
+
+import (
+	"reflect"
+	"testing"
+)
+
+type CallRecord struct {
+	params []any
+	method string
+}
+
+func (cr CallRecord) AssertParams(t *testing.T, want ...any) {
+	t.Helper()
+	got := cr.params
+
+	if len(got) != len(want) {
+		t.Errorf("want %d params for %q, got %d", len(want), cr.method, len(got))
+	}
+
+	l := min(len(want), len(got))
+	for i := range l {
+		if reflect.TypeOf(want[i]) != reflect.TypeOf(got[i]) {
+			t.Errorf("want %T type for param number %d for %q, got %T", want[i], i, cr.method, got[i])
+		} else if !reflect.DeepEqual(want[i], got[i]) {
+			t.Errorf("want %#v for param number %d for %q, got %#v", want[i], i, cr.method, got[i])
+		}
+	}
+}
+
+func (cr CallRecord) AssertMethod(t *testing.T, want string) {
+	t.Helper()
+	if want != cr.method {
+		t.Errorf("want method %q, got %q", want, cr.method)
+	}
+}
+
+type OutputRecord struct {
+	in any
+	th []string
+	td [][]string
+}
+
+func (or OutputRecord) Assert(t *testing.T, wantIn any, wantTh []string, wantTd [][]string) {
+	t.Helper()
+
+	if reflect.TypeOf(wantIn) != reflect.TypeOf(or.in) {
+		t.Errorf("want %T type for output val, got %T", wantIn, or.in)
+	} else if !reflect.DeepEqual(wantIn, or.in) {
+		t.Errorf("want %#v output val, got %#v", wantIn, or.in)
+	}
+
+	if !reflect.DeepEqual(wantTh, or.th) {
+		t.Errorf("want %#v output table header, got %#v", wantTh, or.th)
+	}
+
+	if !reflect.DeepEqual(wantTd, or.td) {
+		t.Errorf("want %#v output table data, got %#v", wantTd, or.td)
+	}
+}

--- a/internal/plans/list.go
+++ b/internal/plans/list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *Client) List() *cobra.Command {
+func (c *Command) list() *cobra.Command {
 	var regionID string
 	var teamID int
 	var types []string
@@ -22,7 +22,7 @@ func (c *Client) List() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			options := c.Servicer.GetOptions()
+			options := c.GetOpts()
 
 			if len(types) > 0 {
 				options.Type = types
@@ -32,7 +32,7 @@ func (c *Client) List() *cobra.Command {
 				options.QueryParams = map[string]string{"region": regionID}
 			}
 
-			plans, _, err := c.Service.List(teamID, options)
+			plans, _, err := c.Client().List(teamID, options)
 			if err != nil {
 				return errors.Wrap(err, "Could not list plans")
 			}
@@ -57,7 +57,7 @@ func (c *Client) List() *cobra.Command {
 			}
 			header := []string{"Plan Slug", "Region Slug", "Stock Hourly", "Hourly Price", "Stock Spot", "Spot Price"}
 
-			return c.Out.Output(plans, header, &data)
+			return c.Outputer().Output(plans, header, &data)
 		},
 	}
 

--- a/internal/plans/list.go
+++ b/internal/plans/list.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (c *Command) list() *cobra.Command {
-	var regionID string
+	var region string
 	var teamID int
 	var types []string
 	planGetCmd := &cobra.Command{
@@ -32,8 +32,8 @@ func (c *Command) list() *cobra.Command {
 				options.Type = types
 			}
 
-			if regionID != "" {
-				options.QueryParams = map[string]string{"region": regionID}
+			if region != "" {
+				options.QueryParams = map[string]string{"region": region}
 			}
 
 			plans, _, err := c.Client().List(teamID, options)
@@ -54,7 +54,7 @@ func (c *Command) list() *cobra.Command {
 				}
 
 				for _, r := range p.AvailableRegions {
-					if regionID == "" || regionID == r.Slug || regionID == strconv.Itoa(r.ID) {
+					if region == "" || region == r.Slug || region == strconv.Itoa(r.ID) {
 						data = append(data, []string{p.Slug, r.Slug, strconv.Itoa(r.StockQty), priceHour, strconv.Itoa(r.SpotQty), priceSpot})
 					}
 				}
@@ -65,7 +65,7 @@ func (c *Command) list() *cobra.Command {
 		},
 	}
 
-	planGetCmd.Flags().StringVarP(&regionID, "region", "r", "", "The Slug or ID of region.")
+	planGetCmd.Flags().StringVarP(&region, "region", "r", "", "The Slug or ID of region.")
 	planGetCmd.Flags().StringSliceVarP(&types, "type", "", []string{}, "Comma separated list of available plan types.")
 	planGetCmd.Flags().IntVarP(&teamID, "team-id", "t", 0, "The team's ID. Return plans prices based on team billing details.")
 

--- a/internal/plans/list.go
+++ b/internal/plans/list.go
@@ -14,7 +14,7 @@ func (c *Command) list() *cobra.Command {
 	var teamID int
 	var types []string
 	planGetCmd := &cobra.Command{
-		Use:     `list -t <team_id> [--region-id <region_slug>] [--type <type>]`,
+		Use:     `list -t <team_id> [--region <region_slug>] [--type <type>]`,
 		Aliases: []string{"get"},
 		Short:   "Retrieves a list of server plans.",
 		Long:    "Retrieves a list of server plans with their corresponding hourly rates and stock volumes.",

--- a/internal/plans/list.go
+++ b/internal/plans/list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/cherryservers/cherrygo/v3"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -23,6 +24,9 @@ func (c *Command) list() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			options := c.GetOpts()
+			if options == nil {
+				options = &cherrygo.GetOptions{}
+			}
 
 			if len(types) > 0 {
 				options.Type = types

--- a/internal/plans/list.go
+++ b/internal/plans/list.go
@@ -66,7 +66,7 @@ func (c *Command) list() *cobra.Command {
 	}
 
 	planGetCmd.Flags().StringVarP(&regionID, "region", "r", "", "The Slug or ID of region.")
-	planGetCmd.Flags().StringSliceVarP(&types, "type", "", []string{}, `Comma separated list of available plan types (baremetal,virtual,vps)`)
+	planGetCmd.Flags().StringSliceVarP(&types, "type", "", []string{}, "Comma separated list of available plan types.")
 	planGetCmd.Flags().IntVarP(&teamID, "team-id", "t", 0, "The team's ID. Return plans prices based on team billing details.")
 
 	planGetCmd.MarkFlagRequired("team-id")

--- a/internal/plans/list_test.go
+++ b/internal/plans/list_test.go
@@ -12,10 +12,11 @@ import (
 type fakeDeps struct {
 	svc *fakes.PlanService
 	out *fakes.Outputer
+	opts *cherrygo.GetOptions
 }
 
-func (td fakeDeps) GetOpts() *cherrygo.GetOptions {
-	return &cherrygo.GetOptions{}
+func (fd fakeDeps) GetOpts() *cherrygo.GetOptions {
+	return fd.opts 
 }
 
 func (fd fakeDeps) Client() cherrygo.PlansService {
@@ -30,6 +31,7 @@ func TestList(t *testing.T) {
 	cases := []struct {
 		title            string
 		args             []string
+		getOpts *cherrygo.GetOptions
 		wantClientParams []any
 	}{
 		{
@@ -61,6 +63,7 @@ func TestList(t *testing.T) {
 			dep := fakeDeps{
 				svc: &fakeSvc,
 				out: &fakeOut,
+				opts: tc.getOpts,
 			}
 
 			c := Command{

--- a/internal/plans/list_test.go
+++ b/internal/plans/list_test.go
@@ -15,7 +15,7 @@ type fakeDeps struct {
 }
 
 func (td fakeDeps) GetOpts() *cherrygo.GetOptions {
-	return nil
+	return &cherrygo.GetOptions{}
 }
 
 func (fd fakeDeps) Client() cherrygo.PlansService {
@@ -27,37 +27,68 @@ func (fd fakeDeps) Outputer() outputs.Outputer {
 }
 
 func TestList(t *testing.T) {
-	fakeSvc := fakes.PlanService{}
-	fakeOut := fakes.Outputer{}
-	dep := fakeDeps{
-		svc: &fakeSvc,
-		out: &fakeOut,
+	cases := []struct {
+		title            string
+		args             []string
+		wantClientParams []any
+	}{
+		{
+			title:            "only team-id",
+			args:             []string{"--team-id", "1"},
+			wantClientParams: []any{1, &cherrygo.GetOptions{}},
+		},
+		{
+			title:            "team-id and region slug",
+			args:             []string{"--team-id", "1", "--region", "test-region"},
+			wantClientParams: []any{1, &cherrygo.GetOptions{QueryParams: map[string]string{"region": "test-region"}}},
+		},
+		{
+			title:            "team-id and region id",
+			args:             []string{"--team-id", "1", "--region", "1"},
+			wantClientParams: []any{1, &cherrygo.GetOptions{QueryParams: map[string]string{"region": "1"}}},
+		},
+		{
+			title:            "shorthands",
+			args:             []string{"-t", "1", "-r", "test-region"},
+			wantClientParams: []any{1, &cherrygo.GetOptions{QueryParams: map[string]string{"region": "test-region"}}},
+		},
 	}
 
-	c := Command{
-		Deps: dep,
-	}
-	cmd := c.list()
-	cmd.SetArgs([]string{"--team-id", "1"})
-	cmd.SilenceUsage = true
+	for _, tc := range cases {
+		t.Run(tc.title, func(t *testing.T) {
+			fakeSvc := fakes.PlanService{}
+			fakeOut := fakes.Outputer{}
+			dep := fakeDeps{
+				svc: &fakeSvc,
+				out: &fakeOut,
+			}
 
-	err := cmd.Execute()
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+			c := Command{
+				Deps: dep,
+			}
+			cmd := c.list()
+			cmd.SetArgs(tc.args)
+			cmd.SilenceUsage = true
 
-	if len(fakeSvc.Calls) != 1 {
-		t.Fatalf("want 1 api call, got %d", len(fakeSvc.Calls))
-	}
-	fakeSvc.Calls[0].AssertMethod(t, "List")
-	fakeSvc.Calls[0].AssertParams(t, 1, (*cherrygo.GetOptions)(nil))
+			err := cmd.Execute()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
 
-	if len(fakeOut.Calls) != 1{
-		t.Fatalf("want 1 output call, got %d", len(fakeOut.Calls))
-	}
+			if len(fakeSvc.Calls) != 1 {
+				t.Fatalf("want 1 api call, got %d", len(fakeSvc.Calls))
+			}
+			fakeSvc.Calls[0].AssertMethod(t, "List")
+			fakeSvc.Calls[0].AssertParams(t, tc.wantClientParams...)
 
-	wantPlan := fakeSvc.Plan()
-	wantTh := []string{"Plan Slug", "Region Slug", "Stock Hourly", "Hourly Price", "Stock Spot", "Spot Price"}
-	wantTd := [][]string{{"test-slug", "test-slug", "1", fmt.Sprintf("%f", 1.0), "2", fmt.Sprintf("%f", 0.5)}}
-	fakeOut.Calls[0].Assert(t, []cherrygo.Plan{wantPlan}, wantTh, wantTd)
+			if len(fakeOut.Calls) != 1 {
+				t.Fatalf("want 1 output call, got %d", len(fakeOut.Calls))
+			}
+
+			wantPlan := fakeSvc.Plan()
+			wantTh := []string{"Plan Slug", "Region Slug", "Stock Hourly", "Hourly Price", "Stock Spot", "Spot Price"}
+			wantTd := [][]string{{"test-plan", "test-region", "1", fmt.Sprintf("%f", 1.0), "2", fmt.Sprintf("%f", 0.5)}}
+			fakeOut.Calls[0].Assert(t, []cherrygo.Plan{wantPlan}, wantTh, wantTd)
+		})
+	}
 }

--- a/internal/plans/list_test.go
+++ b/internal/plans/list_test.go
@@ -1,0 +1,63 @@
+package plans
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cherryservers/cherryctl/internal/fakes"
+	"github.com/cherryservers/cherryctl/internal/outputs"
+	"github.com/cherryservers/cherrygo/v3"
+)
+
+type fakeDeps struct {
+	svc *fakes.PlanService
+	out *fakes.Outputer
+}
+
+func (td fakeDeps) GetOpts() *cherrygo.GetOptions {
+	return nil
+}
+
+func (fd fakeDeps) Client() cherrygo.PlansService {
+	return fd.svc
+}
+
+func (fd fakeDeps) Outputer() outputs.Outputer {
+	return fd.out
+}
+
+func TestList(t *testing.T) {
+	fakeSvc := fakes.PlanService{}
+	fakeOut := fakes.Outputer{}
+	dep := fakeDeps{
+		svc: &fakeSvc,
+		out: &fakeOut,
+	}
+
+	c := Command{
+		Deps: dep,
+	}
+	cmd := c.list()
+	cmd.SetArgs([]string{"--team-id", "1"})
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if len(fakeSvc.Calls) != 1 {
+		t.Fatalf("want 1 api call, got %d", len(fakeSvc.Calls))
+	}
+	fakeSvc.Calls[0].AssertMethod(t, "List")
+	fakeSvc.Calls[0].AssertParams(t, 1, (*cherrygo.GetOptions)(nil))
+
+	if len(fakeOut.Calls) != 1{
+		t.Fatalf("want 1 output call, got %d", len(fakeOut.Calls))
+	}
+
+	wantPlan := fakeSvc.Plan()
+	wantTh := []string{"Plan Slug", "Region Slug", "Stock Hourly", "Hourly Price", "Stock Spot", "Spot Price"}
+	wantTd := [][]string{{"test-slug", "test-slug", "1", fmt.Sprintf("%f", 1.0), "2", fmt.Sprintf("%f", 0.5)}}
+	fakeOut.Calls[0].Assert(t, []cherrygo.Plan{wantPlan}, wantTh, wantTd)
+}

--- a/internal/plans/list_test.go
+++ b/internal/plans/list_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 type fakeDeps struct {
-	svc *fakes.PlanService
-	out *fakes.Outputer
+	svc  *fakes.PlanService
+	out  *fakes.Outputer
 	opts *cherrygo.GetOptions
 }
 
 func (fd fakeDeps) GetOpts() *cherrygo.GetOptions {
-	return fd.opts 
+	return fd.opts
 }
 
 func (fd fakeDeps) Client() cherrygo.PlansService {
@@ -31,7 +31,7 @@ func TestList(t *testing.T) {
 	cases := []struct {
 		title            string
 		args             []string
-		getOpts *cherrygo.GetOptions
+		getOpts          *cherrygo.GetOptions
 		wantClientParams []any
 	}{
 		{
@@ -61,8 +61,8 @@ func TestList(t *testing.T) {
 			fakeSvc := fakes.PlanService{}
 			fakeOut := fakes.Outputer{}
 			dep := fakeDeps{
-				svc: &fakeSvc,
-				out: &fakeOut,
+				svc:  &fakeSvc,
+				out:  &fakeOut,
 				opts: tc.getOpts,
 			}
 

--- a/internal/plans/plan.go
+++ b/internal/plans/plan.go
@@ -4,49 +4,35 @@ import (
 	"github.com/cherryservers/cherryctl/internal/outputs"
 	"github.com/cherryservers/cherrygo/v3"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
-type Client struct {
-	Servicer Servicer
-	Service  cherrygo.PlansService
-	Out      outputs.Outputer
+type Command struct {
+	Deps
 }
 
-func (c *Client) NewCommand() *cobra.Command {
+func (c *Command) CobraCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     `plan`,
 		Aliases: []string{"plans"},
 		Short:   "Plan operations.",
 		Long:    "Plan operations: get, list.",
-
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if root := cmd.Root(); root != nil {
-				if root.PersistentPreRun != nil {
-					root.PersistentPreRun(cmd, args)
-				}
-			}
-
-			c.Service = c.Servicer.API(cmd).Plans
-		},
 	}
 
 	cmd.AddCommand(
-		c.List(),
+		c.list(),
 	)
 
 	return cmd
 }
 
-type Servicer interface {
-	API(*cobra.Command) *cherrygo.Client
-	GetOptions() *cherrygo.GetOptions
-	Config(cmd *cobra.Command) *viper.Viper
+type Deps interface {
+	Client() cherrygo.PlansService
+	GetOpts() *cherrygo.GetOptions
+	Outputer() outputs.Outputer
 }
 
-func NewClient(s Servicer, out outputs.Outputer) *Client {
-	return &Client{
-		Servicer: s,
-		Out:      out,
+func NewCommand(dep Deps) *Command {
+	return &Command{
+		Deps: dep,
 	}
 }


### PR DESCRIPTION
Refactor plan command code to allow easier testing and add some tests. Should serve as an example/starting point for further test code, so that we can move towards reasonable test coverage.