### PR TITLE
Bump cherrygo to v4.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ jobs:
   test:
     name: docs
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: [ '1.24.4' ]
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
@@ -30,7 +27,7 @@ jobs:
           ${{ runner.os }}-go-
     - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: ${{ matrix.go }}
+        go-version-file: 'go.mod'
     - name: Build docs
       run: make generate-docs
     - name: Detect Uncommitted Docs

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cherryservers/cherryctl/internal/storages"
 	"github.com/cherryservers/cherryctl/internal/teams"
 	"github.com/cherryservers/cherryctl/internal/users"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/cherryservers/cherryctl
 
-go 1.24.4
+go 1.25.0
 
 require (
-	github.com/cherryservers/cherrygo/v3 v3.9.1
+	github.com/cherryservers/cherrygo/v4 v4.0.0
 	github.com/google/uuid v1.6.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cherryservers/cherrygo/v3 v3.9.1 h1:2CjRjijh+k4Qf5L2CWTfArniT441K/mjeFKbymbOU7g=
-github.com/cherryservers/cherrygo/v3 v3.9.1/go.mod h1:g7NZMevwRv0oqKMWz2xkBZKPy/Lx5emKiF2fjIIXBGk=
+github.com/cherryservers/cherrygo/v4 v4.0.0 h1:EGQcXESCPz/h/UP8PmlmUhz+2CO4sXqZatJ4IqsDWmA=
+github.com/cherryservers/cherrygo/v4 v4.0.0/go.mod h1:ZJk3JYeFSqSPQ7HIkJa2rOdq0L2mI2Oy3iZwTbWnJgg=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=

--- a/internal/backups/backup.go
+++ b/internal/backups/backup.go
@@ -2,7 +2,7 @@ package backups
 
 import (
 	"github.com/cherryservers/cherryctl/internal/outputs"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/internal/backups/create.go
+++ b/internal/backups/create.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	"github.com/cherryservers/cherryctl/internal/utils"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -28,27 +28,27 @@ func (c *Client) Create() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
 
 			if serverHostname == "" && serverID == 0 {
 				return fmt.Errorf("either server-id or server-hostname should be set")
 			}
 
 			request := &cherrygo.CreateBackup{
-				ServerID:       serverID,
 				BackupPlanSlug: backupPlan,
 				RegionSlug:     region,
 				SSHKey:         sshKey,
 			}
 
 			if serverHostname != "" {
-				srvID, err := utils.ServerHostnameToID(serverHostname, projectID, c.ServerService)
+				srvID, err := utils.ServerHostnameToID(ctx, serverHostname, projectID, c.ServerService)
 				if err != nil {
 					return errors.Wrap(err, "Could not get a Server")
 				}
-				request.ServerID = srvID
+				serverID = srvID
 			}
 
-			o, _, err := c.Service.Create(request)
+			o, _, err := c.Service.Create(ctx, serverID, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not create a backup storage")
 			}

--- a/internal/backups/delete.go
+++ b/internal/backups/delete.go
@@ -27,6 +27,8 @@ func (c *Client) Delete() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if storID, err := strconv.Atoi(args[0]); err == nil {
 				storageID = storID
 			}
@@ -42,7 +44,7 @@ func (c *Client) Delete() *cobra.Command {
 				}
 			}
 
-			_, err := c.Service.Delete(storageID)
+			_, err := c.Service.Delete(ctx, storageID)
 			if err != nil {
 				return errors.Wrap(err, "Could not delete a backup storage")
 			}

--- a/internal/backups/get.go
+++ b/internal/backups/get.go
@@ -20,11 +20,13 @@ func (c *Client) Get() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if storID, err := strconv.Atoi(args[0]); err == nil {
 				storageID = storID
 			}
 
-			o, _, err := c.Service.Get(storageID, c.Servicer.GetOptions())
+			o, _, err := c.Service.Get(ctx, storageID, c.Servicer.GetOptions())
 			if err != nil {
 				return errors.Wrap(err, "Could not get a backup storage")
 			}

--- a/internal/backups/list.go
+++ b/internal/backups/list.go
@@ -19,7 +19,9 @@ func (c *Client) List() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			storages, _, err := c.Service.ListBackups(projectID, c.Servicer.GetOptions())
+			ctx := cmd.Context()
+
+			storages, _, err := c.Service.ListBackups(ctx, projectID, c.Servicer.GetOptions())
 			if err != nil {
 				return errors.Wrap(err, "Could not get backup storage list")
 			}

--- a/internal/backups/methods.go
+++ b/internal/backups/methods.go
@@ -22,11 +22,13 @@ func (c *Client) Methods() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if backID, err := strconv.Atoi(args[0]); err == nil {
 				backupID = backID
 			}
 
-			storage, _, err := c.Service.Get(backupID, nil)
+			storage, _, err := c.Service.Get(ctx, backupID, nil)
 			if err != nil {
 				return errors.Wrap(err, "Could not get a backup storage")
 			}

--- a/internal/backups/methods_whitelist.go
+++ b/internal/backups/methods_whitelist.go
@@ -21,11 +21,13 @@ func (c *Client) MethodsWhitelist() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if backID, err := strconv.Atoi(args[0]); err == nil {
 				backupID = backID
 			}
 
-			storage, _, err := c.Service.Get(backupID, nil)
+			storage, _, err := c.Service.Get(ctx, backupID, nil)
 			if err != nil {
 				return errors.Wrap(err, "Could not get a backup storage")
 			}

--- a/internal/backups/plans.go
+++ b/internal/backups/plans.go
@@ -19,8 +19,9 @@ func (c *Client) Plans() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
 
-			plans, _, err := c.Service.ListPlans(c.Servicer.GetOptions())
+			plans, _, err := c.Service.ListPlans(ctx, c.Servicer.GetOptions())
 			if err != nil {
 				return errors.Wrap(err, "Could not get backup storage plan list")
 			}

--- a/internal/backups/update.go
+++ b/internal/backups/update.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -29,17 +29,18 @@ func (c *Client) Update() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if backID, err := strconv.Atoi(args[0]); err == nil {
 				backupID = backID
 			}
 			request := &cherrygo.UpdateBackupStorage{
-				BackupStorageID: backupID,
 				BackupPlanSlug:  plan,
 				Password:        password,
 				SSHKey:          sshKey,
 			}
 
-			o, _, err := c.Service.Update(request)
+			o, _, err := c.Service.Update(ctx, backupID, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not update backup storage")
 			}

--- a/internal/backups/update.go
+++ b/internal/backups/update.go
@@ -35,9 +35,9 @@ func (c *Client) Update() *cobra.Command {
 				backupID = backID
 			}
 			request := &cherrygo.UpdateBackupStorage{
-				BackupPlanSlug:  plan,
-				Password:        password,
-				SSHKey:          sshKey,
+				BackupPlanSlug: plan,
+				Password:       password,
+				SSHKey:         sshKey,
 			}
 
 			o, _, err := c.Service.Update(ctx, backupID, request)

--- a/internal/backups/update_method.go
+++ b/internal/backups/update_method.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/cherryservers/cherryctl/internal/utils"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -29,26 +29,29 @@ func (c *Client) UpdateMethod() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if backID, err := strconv.Atoi(args[0]); err == nil {
 				backupID = backID
 			}
 
-			request := &cherrygo.UpdateBackupMethod{
-				BackupStorageID:  backupID,
-				BackupMethodName: serviceName,
-			}
+			request := &cherrygo.UpdateBackupMethod{}
 
 			if len(ipWhitelist) == 0 || (len(ipWhitelist) > 0 && ipWhitelist[0] != "0") {
-				request.Whitelist = ipWhitelist
+				request.Whitelist = &ipWhitelist
 			}
 
+			var enabled *bool
 			if enable {
-				request.Enabled = true
+				enabled = new(bool)
+				*enabled = true
 			} else if disable {
-				request.Enabled = false
+				enabled = new(bool)
 			}
 
-			services, _, err := c.Service.UpdateBackupMethod(request)
+			request.Enabled = enabled
+
+			services, _, err := c.Service.UpdateBackupMethod(ctx, backupID, serviceName, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not update backup storage access method")
 			}
@@ -69,6 +72,7 @@ func (c *Client) UpdateMethod() *cobra.Command {
 	backupUpdateCmd.Flags().BoolVarP(&disable, "disable", "d", false, "Disable method.")
 
 	backupUpdateCmd.MarkFlagRequired("method-name")
+	backupUpdateCmd.MarkFlagsMutuallyExclusive("enable", "disable")
 
 	return backupUpdateCmd
 }

--- a/internal/backups/upgrade.go
+++ b/internal/backups/upgrade.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -24,15 +24,16 @@ func (c *Client) Upgrade() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if backID, err := strconv.Atoi(args[0]); err == nil {
 				backupID = backID
 			}
 			request := &cherrygo.UpdateBackupStorage{
-				BackupStorageID: backupID,
 				BackupPlanSlug:  plan,
 			}
 
-			o, _, err := c.Service.Update(request)
+			o, _, err := c.Service.Update(ctx, backupID, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not upgrade backup storage")
 			}

--- a/internal/backups/upgrade.go
+++ b/internal/backups/upgrade.go
@@ -30,7 +30,7 @@ func (c *Client) Upgrade() *cobra.Command {
 				backupID = backID
 			}
 			request := &cherrygo.UpdateBackupStorage{
-				BackupPlanSlug:  plan,
+				BackupPlanSlug: plan,
 			}
 
 			o, _, err := c.Service.Update(ctx, backupID, request)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/cherryservers/cherryctl/internal/outputs"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -54,7 +54,7 @@ func (c *Client) API(cmd *cobra.Command) *cherrygo.Client {
 	}
 
 	if c.apiClient == nil {
-		args := []cherrygo.ClientOpt{cherrygo.WithAuthToken(c.apiKey), cherrygo.WithUserAgent("cherry-cli/" + c.Version)}
+		args := []cherrygo.ClientOpt{cherrygo.WithAPIKey(c.apiKey), cherrygo.WithUserAgent("cherry-cli/" + c.Version)}
 
 		if c.apiURL != "" {
 			args = append(args, cherrygo.WithURL(c.apiURL))

--- a/internal/fakes/plan.go
+++ b/internal/fakes/plan.go
@@ -1,27 +1,36 @@
 package fakes
 
 import (
+	"context"
 	"errors"
 
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 )
 
 type PlanService struct {
 	Calls []CallRecord
 }
 
-func (s *PlanService) List(teamID int, opts *cherrygo.GetOptions) ([]cherrygo.Plan, *cherrygo.Response, error) {
+func (s *PlanService) List(ctx context.Context, teamID int, opts *cherrygo.GetOptions) ([]cherrygo.Plan, *cherrygo.Response, error) {
 	s.Calls = append(s.Calls, CallRecord{method: "List", params: []any{teamID, opts}})
 	return []cherrygo.Plan{s.Plan()}, nil, nil
 }
 
-func (s *PlanService) GetBySlug(slug string, opts *cherrygo.GetOptions) (cherrygo.Plan, *cherrygo.Response, error) {
+func (s *PlanService) GetBySlug(ctx context.Context, slug string, opts *cherrygo.GetOptions) (cherrygo.Plan, *cherrygo.Response, error) {
 	s.Calls = append(s.Calls, CallRecord{method: "GetBySlug", params: []any{slug, opts}})
 	return s.Plan(), nil, nil
 }
 
-func (s *PlanService) GetByID(_ int, _ *cherrygo.GetOptions) (cherrygo.Plan, *cherrygo.Response, error) {
+func (s *PlanService) GetByID(_ context.Context, _ int, _ *cherrygo.GetOptions) (cherrygo.Plan, *cherrygo.Response, error) {
 	return cherrygo.Plan{}, nil, errors.New("not implemented")
+}
+
+func (s *PlanService) ListPrebuiltPlans(_ context.Context, _, _ string, _ *cherrygo.GetOptions) ([]cherrygo.PrebuiltPlan, *cherrygo.Response, error) {
+	return []cherrygo.PrebuiltPlan{}, nil, errors.New("not implemented")
+}
+
+func (s *PlanService) ListPrebuiltTeamPlans(_ context.Context, _, _ string, _ int, _ *cherrygo.GetOptions) ([]cherrygo.PrebuiltPlan, *cherrygo.Response, error) {
+	return []cherrygo.PrebuiltPlan{}, nil, errors.New("not implemented")
 }
 
 // Plan is the plan that will be returned by the fake methods.

--- a/internal/images/image.go
+++ b/internal/images/image.go
@@ -2,7 +2,7 @@ package images
 
 import (
 	"github.com/cherryservers/cherryctl/internal/outputs"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/internal/images/list.go
+++ b/internal/images/list.go
@@ -19,7 +19,9 @@ func (c *Client) List() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			images, _, err := c.Service.List(plan, c.Servicer.GetOptions())
+			ctx := cmd.Context()
+
+			images, _, err := c.Service.List(ctx, plan, c.Servicer.GetOptions())
 			if err != nil {
 				return errors.Wrap(err, "Could not list images")
 			}

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -1,8 +1,8 @@
 package init
 
 import (
+	"context"
 	"fmt"
-	"github.com/cherryservers/cherryctl/internal/cli"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -10,7 +10,9 @@ import (
 	"syscall"
 	"text/tabwriter"
 
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherryctl/internal/cli"
+
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -90,12 +92,12 @@ The configuration directory path can be changed with the CHERRY_CONFIG environme
 
 			cherryClient := c.Servicer.API(cmd)
 
-			userTeam, err := c.readUserTeam(cherryClient)
+			userTeam, err := c.readUserTeam(cmd.Context(), cherryClient)
 			if err != nil {
 				return err
 			}
 
-			userProj, err := c.readUserProject(cherryClient, userTeam)
+			userProj, err := c.readUserProject(cmd.Context(), cherryClient, userTeam)
 			if err != nil {
 				return err
 			}
@@ -134,15 +136,15 @@ func (c *Client) readAPIKey() (string, error) {
 func (c *Client) validateAPIKey(cmd *cobra.Command) error {
 	cherryClient := c.Servicer.API(cmd)
 	c.UserService = cherryClient.Users
-	_, _, err := c.UserService.CurrentUser(nil)
+	_, _, err := c.UserService.CurrentUser(cmd.Context(), nil)
 	if err != nil {
 		return errors.Wrap(err, "Invalid API key")
 	}
 	return nil
 }
 
-func (c *Client) readUserTeam(cherryClient *cherrygo.Client) (string, error) {
-	teams, _, err := cherryClient.Teams.List(&cherrygo.GetOptions{})
+func (c *Client) readUserTeam(ctx context.Context, cherryClient *cherrygo.Client) (string, error) {
+	teams, _, err := cherryClient.Teams.List(ctx, &cherrygo.GetOptions{})
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to get team list")
 	}
@@ -165,9 +167,9 @@ func (c *Client) readUserTeam(cherryClient *cherrygo.Client) (string, error) {
 	return userTeam, nil
 }
 
-func (c *Client) readUserProject(cherryClient *cherrygo.Client, userTeam string) (string, error) {
+func (c *Client) readUserProject(ctx context.Context, cherryClient *cherrygo.Client, userTeam string) (string, error) {
 	teamID, _ := strconv.Atoi(userTeam)
-	projects, _, err := cherryClient.Projects.List(teamID, &cherrygo.GetOptions{})
+	projects, _, err := cherryClient.Projects.List(ctx, teamID, &cherrygo.GetOptions{})
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to get project list")
 	}

--- a/internal/ips/assign.go
+++ b/internal/ips/assign.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/cherryservers/cherryctl/internal/utils"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -28,6 +28,8 @@ func (c *Client) Assign() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			request := &cherrygo.AssignIPAddress{}
 
 			if utils.IsValidUUID(args[0]) {
@@ -38,13 +40,13 @@ func (c *Client) Assign() *cobra.Command {
 			}
 
 			if targetIPID != "" && utils.IsValidUUID(targetIPID) {
-				request.IpID = targetIPID
+				request.RoutedTo = targetIPID
 			} else if targetHostname != "" {
 				if projectID == 0 {
 					fmt.Println("--project-id argument is required with --target-hostname.")
 					return nil
 				}
-				srvID, err := utils.ServerHostnameToID(targetHostname, projectID, c.ServerService)
+				srvID, err := utils.ServerHostnameToID(ctx, targetHostname, projectID, c.ServerService)
 				if err != nil {
 					return errors.Wrap(err, "Could not find a target by hostname")
 				}
@@ -53,18 +55,18 @@ func (c *Client) Assign() *cobra.Command {
 				request.ServerID = targetID
 			}
 
-			if request.ServerID == 0 && request.IpID == "" {
+			if request.ServerID == 0 && request.RoutedTo == "" {
 				return errors.New("Could not find a target")
 			}
 
-			i, _, err := c.Service.Assign(ipID, request)
+			i, _, err := c.Service.Assign(ctx, ipID, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not assign IP address")
 			}
 
 			header := []string{"ID", "Address", "Cidr", "Type", "Region"}
 			data := make([][]string, 1)
-			data[0] = []string{i.ID, i.Address, i.Cidr, i.Type, i.Region.Name}
+			data[0] = []string{i.ID, i.Address, i.CIDR, i.Type, i.Region.Name}
 
 			return c.Out.Output(i, header, &data)
 		},

--- a/internal/ips/create.go
+++ b/internal/ips/create.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/cherryservers/cherryctl/internal/utils"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -32,6 +32,8 @@ func (c *Client) Create() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			tagsArr := make(map[string]string)
 
 			for _, kv := range tags {
@@ -46,7 +48,7 @@ func (c *Client) Create() *cobra.Command {
 			}
 
 			if targetHostname != "" {
-				srvID, err := utils.ServerHostnameToID(targetHostname, projectID, c.ServerService)
+				srvID, err := utils.ServerHostnameToID(ctx, targetHostname, projectID, c.ServerService)
 				if err != nil {
 					return errors.Wrap(err, "Could not find a target by hostname")
 				}
@@ -59,21 +61,21 @@ func (c *Client) Create() *cobra.Command {
 
 			request := &cherrygo.CreateIPAddress{
 				Region:     region,
-				PtrRecord:  ptrRecord,
+				PTRRecord:  ptrRecord,
 				ARecord:    aRecord,
 				TargetedTo: target,
 				RoutedTo:   route,
 				Tags:       &tagsArr,
 			}
 
-			i, _, err := c.Service.Create(projectID, request)
+			i, _, err := c.Service.Create(ctx, projectID, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not create IP address")
 			}
 
 			header := []string{"ID", "Address", "Cidr", "Type", "Region", "PTR record", "A record", "Tags"}
 			data := make([][]string, 1)
-			data[0] = []string{i.ID, i.Address, i.Cidr, i.Type, i.Region.Name, i.PtrRecord, i.ARecord, utils.FormatStringTags(i.Tags)}
+			data[0] = []string{i.ID, i.Address, i.CIDR, i.Type, i.Region.Name, i.PTRRecord, i.ARecord, utils.FormatStringTags(i.Tags)}
 
 			return c.Out.Output(i, header, &data)
 		},

--- a/internal/ips/delete.go
+++ b/internal/ips/delete.go
@@ -27,6 +27,8 @@ func (c *Client) Delete() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if utils.IsValidUUID(args[0]) {
 				ipID = args[0]
 			} else {
@@ -45,7 +47,7 @@ func (c *Client) Delete() *cobra.Command {
 					return nil
 				}
 			}
-			_, err := c.Service.Remove(ipID)
+			_, err := c.Service.Remove(ctx, ipID)
 			if err != nil {
 				return errors.Wrap(err, "Could not delete IP address")
 			}

--- a/internal/ips/get.go
+++ b/internal/ips/get.go
@@ -20,6 +20,8 @@ func (c *Client) Get() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if utils.IsValidUUID(args[0]) {
 				ipID = args[0]
 			} else {
@@ -29,14 +31,14 @@ func (c *Client) Get() *cobra.Command {
 
 			getOptions := c.Servicer.GetOptions()
 			getOptions.Fields = []string{"ip", "region", "hostname"}
-			i, _, err := c.Service.Get(ipID, getOptions)
+			i, _, err := c.Service.Get(ctx, ipID, getOptions)
 			if err != nil {
 				return errors.Wrap(err, "Could not get IP address")
 			}
 
 			header := []string{"ID", "Address", "Cidr", "Type", "Target", "Region", "PTR record", "A record", "Tags"}
 			data := make([][]string, 1)
-			data[0] = []string{i.ID, i.Address, i.Cidr, i.Type, i.TargetedTo.Hostname, i.Region.Name, i.PtrRecord, i.ARecord, utils.FormatStringTags(i.Tags)}
+			data[0] = []string{i.ID, i.Address, i.CIDR, i.Type, i.TargetedTo.Hostname, i.Region.Name, i.PTRRecord, i.ARecord, utils.FormatStringTags(i.Tags)}
 
 			return c.Out.Output(i, header, &data)
 		},

--- a/internal/ips/ip.go
+++ b/internal/ips/ip.go
@@ -2,14 +2,14 @@ package ips
 
 import (
 	"github.com/cherryservers/cherryctl/internal/outputs"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 type Client struct {
 	Servicer      Servicer
-	Service       cherrygo.IpAddressesService
+	Service       cherrygo.IPAddressesService
 	ServerService cherrygo.ServersService
 	Out           outputs.Outputer
 }

--- a/internal/ips/list.go
+++ b/internal/ips/list.go
@@ -18,6 +18,8 @@ func (c *Client) List() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			getOptions := c.Servicer.GetOptions()
 			getOptions.Fields = []string{"ip", "region", "hostname"}
 
@@ -25,14 +27,14 @@ func (c *Client) List() *cobra.Command {
 				getOptions.Type = types
 			}
 
-			ips, _, err := c.Service.List(projectID, getOptions)
+			ips, _, err := c.Service.List(ctx, projectID, getOptions)
 			if err != nil {
 				return errors.Wrap(err, "Could not list servers")
 			}
 			data := make([][]string, len(ips))
 
 			for i, ip := range ips {
-				data[i] = []string{ip.ID, ip.Address, ip.Cidr, ip.Type, ip.TargetedTo.Hostname, ip.Region.Name, ip.PtrRecord, ip.ARecord, utils.FormatStringTags(ip.Tags)}
+				data[i] = []string{ip.ID, ip.Address, ip.CIDR, ip.Type, ip.TargetedTo.Hostname, ip.Region.Name, ip.PTRRecord, ip.ARecord, utils.FormatStringTags(ip.Tags)}
 			}
 			header := []string{"ID", "Address", "Cidr", "Type", "Target", "Region", "PTR record", "A record", "Tags"}
 

--- a/internal/ips/unassign.go
+++ b/internal/ips/unassign.go
@@ -23,6 +23,8 @@ func (c *Client) Unassign() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if utils.IsValidUUID(args[0]) {
 				ipID = args[0]
 			} else {
@@ -30,7 +32,7 @@ func (c *Client) Unassign() *cobra.Command {
 				return nil
 			}
 
-			_, err := c.Service.Unassign(ipID)
+			_, err := c.Service.Unassign(ctx, ipID)
 			if err != nil {
 				return errors.Wrap(err, "Could not unassign IP address")
 			}

--- a/internal/ips/update.go
+++ b/internal/ips/update.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/cherryservers/cherryctl/internal/utils"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +27,8 @@ func (c *Client) Update() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if utils.IsValidUUID(args[0]) {
 				ipID = args[0]
 			} else {
@@ -47,7 +49,7 @@ func (c *Client) Update() *cobra.Command {
 			}
 
 			request := &cherrygo.UpdateIPAddress{
-				PtrRecord: ptrRecord,
+				PTRRecord: ptrRecord,
 				ARecord:   aRecord,
 			}
 
@@ -55,14 +57,14 @@ func (c *Client) Update() *cobra.Command {
 				request.Tags = &tagsArr
 			}
 
-			i, _, err := c.Service.Update(ipID, request)
+			i, _, err := c.Service.Update(ctx, ipID, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not update IP address")
 			}
 
 			header := []string{"ID", "Address", "Cidr", "Type", "Region", "PTR record", "A record", "Tags"}
 			data := make([][]string, 1)
-			data[0] = []string{i.ID, i.Address, i.Cidr, i.Type, i.Region.Name, i.PtrRecord, i.ARecord, utils.FormatStringTags(i.Tags)}
+			data[0] = []string{i.ID, i.Address, i.CIDR, i.Type, i.Region.Name, i.PTRRecord, i.ARecord, utils.FormatStringTags(i.Tags)}
 
 			return c.Out.Output(i, header, &data)
 		},

--- a/internal/plans/list.go
+++ b/internal/plans/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -23,6 +23,8 @@ func (c *Command) list() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			options := c.GetOpts()
 			if options == nil {
 				options = &cherrygo.GetOptions{}
@@ -36,7 +38,7 @@ func (c *Command) list() *cobra.Command {
 				options.QueryParams = map[string]string{"region": region}
 			}
 
-			plans, _, err := c.Client().List(teamID, options)
+			plans, _, err := c.Client().List(ctx, teamID, options)
 			if err != nil {
 				return errors.Wrap(err, "Could not list plans")
 			}

--- a/internal/plans/list_test.go
+++ b/internal/plans/list_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/cherryservers/cherryctl/internal/fakes"
 	"github.com/cherryservers/cherryctl/internal/outputs"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 )
 
 type fakeDeps struct {

--- a/internal/plans/plan.go
+++ b/internal/plans/plan.go
@@ -2,7 +2,7 @@ package plans
 
 import (
 	"github.com/cherryservers/cherryctl/internal/outputs"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/projects/create.go
+++ b/internal/projects/create.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 
 	"github.com/cherryservers/cherryctl/internal/utils"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -24,19 +24,21 @@ func (c *Client) Create() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			request := &cherrygo.CreateProject{
 				Name: name,
-				Bgp:  bgp,
+				BGP:  bgp,
 			}
 
-			o, _, err := c.Service.Create(teamID, request)
+			o, _, err := c.Service.Create(ctx, teamID, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not create project")
 			}
 
 			header := []string{"ID", "Name", "BGP enabled", "BGP ASN"}
 			data := make([][]string, 1)
-			data[0] = []string{strconv.Itoa(o.ID), o.Name, utils.BoolToYesNo(o.Bgp.Enabled), strconv.Itoa(o.Bgp.LocalASN)}
+			data[0] = []string{strconv.Itoa(o.ID), o.Name, utils.BoolToYesNo(o.BGP.Enabled), strconv.Itoa(o.BGP.LocalASN)}
 
 			return c.Out.Output(o, header, &data)
 		},

--- a/internal/projects/delete.go
+++ b/internal/projects/delete.go
@@ -26,6 +26,8 @@ func (c *Client) Delete() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if len(args) > 0 {
 				prID, err := strconv.Atoi(args[0])
 				if err == nil {
@@ -44,7 +46,7 @@ func (c *Client) Delete() *cobra.Command {
 					return nil
 				}
 			}
-			_, err := c.Service.Delete(projectID)
+			_, err := c.Service.Delete(ctx, projectID)
 			if err != nil {
 				return errors.Wrap(err, "Could not delete a Project")
 			}

--- a/internal/projects/get.go
+++ b/internal/projects/get.go
@@ -20,6 +20,8 @@ func (c *Client) Get() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if len(args) > 0 {
 				prID, err := strconv.Atoi(args[0])
 				if err == nil {
@@ -31,14 +33,14 @@ func (c *Client) Get() *cobra.Command {
 				return fmt.Errorf("project-id should be set %v\t", projectID)
 			}
 
-			o, _, err := c.Service.Get(projectID, c.Servicer.GetOptions())
+			o, _, err := c.Service.Get(ctx, projectID, c.Servicer.GetOptions())
 			if err != nil {
 				return errors.Wrap(err, "Could not get project")
 			}
 
 			header := []string{"ID", "Name", "BGP enabled", "BGP ASN"}
 			data := make([][]string, 1)
-			data[0] = []string{strconv.Itoa(o.ID), o.Name, utils.BoolToYesNo(o.Bgp.Enabled), strconv.Itoa(o.Bgp.LocalASN)}
+			data[0] = []string{strconv.Itoa(o.ID), o.Name, utils.BoolToYesNo(o.BGP.Enabled), strconv.Itoa(o.BGP.LocalASN)}
 
 			return c.Out.Output(o, header, &data)
 		},

--- a/internal/projects/list.go
+++ b/internal/projects/list.go
@@ -20,18 +20,20 @@ func (c *Client) List() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if teamID == 0 {
 				return fmt.Errorf("team-id should be set %v\t", teamID)
 			}
 
-			projects, _, err := c.Service.List(teamID, c.Servicer.GetOptions())
+			projects, _, err := c.Service.List(ctx, teamID, c.Servicer.GetOptions())
 			if err != nil {
 				return errors.Wrap(err, "Could not get projects list")
 			}
 
 			data := make([][]string, len(projects))
 			for i, o := range projects {
-				data[i] = []string{strconv.Itoa(o.ID), o.Name, utils.BoolToYesNo(o.Bgp.Enabled), strconv.Itoa(o.Bgp.LocalASN)}
+				data[i] = []string{strconv.Itoa(o.ID), o.Name, utils.BoolToYesNo(o.BGP.Enabled), strconv.Itoa(o.BGP.LocalASN)}
 			}
 			header := []string{"ID", "Name", "BGP enabled", "BGP ASN"}
 

--- a/internal/projects/project.go
+++ b/internal/projects/project.go
@@ -2,7 +2,7 @@ package projects
 
 import (
 	"github.com/cherryservers/cherryctl/internal/outputs"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/internal/projects/update.go
+++ b/internal/projects/update.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 
 	"github.com/cherryservers/cherryctl/internal/utils"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -24,6 +24,8 @@ func (c *Client) Update() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if len(args) > 0 {
 				prID, err := strconv.Atoi(args[0])
 				if err == nil {
@@ -32,21 +34,21 @@ func (c *Client) Update() *cobra.Command {
 			}
 
 			request := &cherrygo.UpdateProject{
-				Bgp: &bgp,
+				BGP: &bgp,
 			}
 
 			if name != "" {
 				request.Name = &name
 			}
 
-			o, _, err := c.Service.Update(projectID, request)
+			o, _, err := c.Service.Update(ctx, projectID, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not update project")
 			}
 
 			header := []string{"ID", "Name", "BGP enabled", "BGP ASN"}
 			data := make([][]string, 1)
-			data[0] = []string{strconv.Itoa(o.ID), o.Name, utils.BoolToYesNo(o.Bgp.Enabled), strconv.Itoa(o.Bgp.LocalASN)}
+			data[0] = []string{strconv.Itoa(o.ID), o.Name, utils.BoolToYesNo(o.BGP.Enabled), strconv.Itoa(o.BGP.LocalASN)}
 
 			return c.Out.Output(o, header, &data)
 		},

--- a/internal/regions/get.go
+++ b/internal/regions/get.go
@@ -20,15 +20,17 @@ func (c *Client) Get() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			regionID = args[0]
-			o, _, err := c.Service.Get(regionID, c.Servicer.GetOptions())
+			o, _, err := c.Service.Get(ctx, regionID, c.Servicer.GetOptions())
 			if err != nil {
 				return errors.Wrap(err, "Could not get a region")
 			}
 
 			header := []string{"ID", "Slug", "Name", "BGP hosts", "BGP asn"}
 			data := make([][]string, 1)
-			data[0] = []string{strconv.Itoa(o.ID), o.Slug, o.Name, strings.Join(o.BGP.Hosts, ", "), strconv.Itoa(o.BGP.Asn)}
+			data[0] = []string{strconv.Itoa(o.ID), o.Slug, o.Name, strings.Join(o.BGP.Hosts, ", "), strconv.Itoa(o.BGP.ASN)}
 
 			return c.Out.Output(o, header, &data)
 		},

--- a/internal/regions/list.go
+++ b/internal/regions/list.go
@@ -18,7 +18,9 @@ func (c *Client) List() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			list, _, err := c.Service.List(c.Servicer.GetOptions())
+			ctx := cmd.Context()
+
+			list, _, err := c.Service.List(ctx, c.Servicer.GetOptions())
 			if err != nil {
 				return errors.Wrap(err, "Could not get regions list")
 			}
@@ -27,7 +29,7 @@ func (c *Client) List() *cobra.Command {
 			header := []string{"ID", "Slug", "Name", "BGP hosts", "BGP asn"}
 
 			for i, o := range list {
-				data[i] = []string{strconv.Itoa(o.ID), o.Slug, o.Name, strings.Join(o.BGP.Hosts, ", "), strconv.Itoa(o.BGP.Asn)}
+				data[i] = []string{strconv.Itoa(o.ID), o.Slug, o.Name, strings.Join(o.BGP.Hosts, ", "), strconv.Itoa(o.BGP.ASN)}
 			}
 
 			return c.Out.Output(list, header, &data)

--- a/internal/regions/region.go
+++ b/internal/regions/region.go
@@ -2,7 +2,7 @@ package regions
 
 import (
 	"github.com/cherryservers/cherryctl/internal/outputs"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/internal/servers/create.go
+++ b/internal/servers/create.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/cherryservers/cherryctl/internal/utils"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -40,6 +40,8 @@ func (c *Client) Create() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			tagsArr := make(map[string]string)
 
 			userDataRaw, err := utils.ReadOptionalFile(userDataPath)
@@ -81,7 +83,7 @@ func (c *Client) Create() *cobra.Command {
 				IPXE:            base64.StdEncoding.EncodeToString(ipxeRaw),
 			}
 
-			s, _, err := c.Service.Create(request)
+			s, _, err := c.Service.Create(ctx, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not provision a server")
 			}

--- a/internal/servers/delete.go
+++ b/internal/servers/delete.go
@@ -26,6 +26,8 @@ func (c *Client) Delete() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if !force {
 				prompt := promptui.Prompt{
 					Label:     fmt.Sprintf("Are you sure you want to delete server %s: ", args[0]),
@@ -39,7 +41,7 @@ func (c *Client) Delete() *cobra.Command {
 			}
 
 			if serverID, err := strconv.Atoi(args[0]); err == nil {
-				_, _, err := c.Service.Delete(serverID)
+				_, err := c.Service.Delete(ctx, serverID)
 				if err != nil {
 					return errors.Wrap(err, "Could not delete Server")
 				}

--- a/internal/servers/enter_rescue.go
+++ b/internal/servers/enter_rescue.go
@@ -2,7 +2,7 @@ package servers
 
 import (
 	"fmt"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -22,13 +22,14 @@ func (c *Client) EnterRescue() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
 
 			request := &cherrygo.RescueServerFields{
 				Password: password,
 			}
 
 			if serverID, err := strconv.Atoi(args[0]); err == nil {
-				_, _, err := c.Service.EnterRescueMode(serverID, request)
+				_, _, err := c.Service.EnterRescueMode(ctx, serverID, request)
 				if err != nil {
 					return errors.Wrap(err, "Couldn't put server in rescue mode.")
 				}

--- a/internal/servers/exit_rescue.go
+++ b/internal/servers/exit_rescue.go
@@ -19,9 +19,10 @@ func (c *Client) ExitRescue() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
 
 			if serverID, err := strconv.Atoi(args[0]); err == nil {
-				_, _, err := c.Service.ExitRescueMode(serverID)
+				_, _, err := c.Service.ExitRescueMode(ctx, serverID)
 				if err != nil {
 					return errors.Wrap(err, "Could not put server out of rescue mode.")
 				}

--- a/internal/servers/get.go
+++ b/internal/servers/get.go
@@ -26,6 +26,7 @@ func (c *Client) Get() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
 
 			if srvID, err := strconv.Atoi(args[0]); err == nil {
 				serverID = srvID
@@ -33,14 +34,14 @@ func (c *Client) Get() *cobra.Command {
 				if projectID == 0 {
 					return errors.Wrap(err, "server get by hostname requires project-id argument.")
 				}
-				srvID, err := utils.ServerHostnameToID(args[0], projectID, c.Service)
+				srvID, err := utils.ServerHostnameToID(ctx, args[0], projectID, c.Service)
 				if err != nil {
 					return errors.Wrap(err, "Server with hostname %s was not found")
 				}
 				serverID = srvID
 			}
 
-			s, _, err := c.Service.Get(serverID, c.Servicer.GetOptions())
+			s, _, err := c.Service.Get(ctx, serverID, c.Servicer.GetOptions())
 			if err != nil {
 				return errors.Wrap(err, "Could not get a Server")
 			}

--- a/internal/servers/list.go
+++ b/internal/servers/list.go
@@ -21,6 +21,7 @@ func (c *Client) List() *cobra.Command {
 		cherryctl server list -p 12345`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			if projectID == 0 {
 				return fmt.Errorf("project-id should be set %v\t", projectID)
 			}
@@ -32,7 +33,7 @@ func (c *Client) List() *cobra.Command {
 			}
 
 			cmd.SilenceUsage = true
-			servers, _, err := c.Service.List(projectID, options)
+			servers, _, err := c.Service.List(ctx, projectID, options)
 			if err != nil {
 				return errors.Wrap(err, "Could not list servers")
 			}

--- a/internal/servers/list_cycles.go
+++ b/internal/servers/list_cycles.go
@@ -17,9 +17,10 @@ func (c *Client) ListCycles() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options := c.Servicer.GetOptions()
+			ctx := cmd.Context()
 
 			cmd.SilenceUsage = true
-			cycles, _, err := c.Service.ListCycles(options)
+			cycles, _, err := c.Service.ListCycles(ctx, options)
 			if err != nil {
 				return errors.Wrap(err, "Could not list server billing cycles.")
 			}

--- a/internal/servers/reboot.go
+++ b/internal/servers/reboot.go
@@ -19,8 +19,10 @@ func (c *Client) Reboot() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if serverID, err := strconv.Atoi(args[0]); err == nil {
-				_, _, err := c.Service.Reboot(serverID)
+				_, _, err := c.Service.Reboot(ctx, serverID)
 				if err != nil {
 					return errors.Wrap(err, "Could not reboot a Server")
 				}

--- a/internal/servers/reinstall.go
+++ b/internal/servers/reinstall.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/cherryservers/cherryctl/internal/utils"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -32,6 +32,7 @@ func (c *Client) Reinstall() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
 
 			userDataRaw, err := utils.ReadOptionalFile(userDataPath)
 			if err != nil {
@@ -54,7 +55,7 @@ func (c *Client) Reinstall() *cobra.Command {
 			}
 
 			if serverID, err := strconv.Atoi(args[0]); err == nil {
-				_, _, err := c.Service.Reinstall(serverID, request)
+				_, _, err := c.Service.Reinstall(ctx, serverID, request)
 				if err != nil {
 					return errors.Wrap(err, "Could not reinstall a Server.")
 				}

--- a/internal/servers/resetbmc.go
+++ b/internal/servers/resetbmc.go
@@ -20,8 +20,10 @@ func (c *Client) ResetBMC() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if serverID, err := strconv.Atoi(args[0]); err == nil {
-				_, _, err := c.Service.ResetBMCPassword(serverID)
+				_, _, err := c.Service.ResetBMCPassword(ctx, serverID)
 				if err != nil {
 					return errors.Wrap(err, "Could not reset server BMC password")
 				}

--- a/internal/servers/server.go
+++ b/internal/servers/server.go
@@ -2,7 +2,7 @@ package servers
 
 import (
 	"github.com/cherryservers/cherryctl/internal/outputs"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/internal/servers/start.go
+++ b/internal/servers/start.go
@@ -19,9 +19,10 @@ func (c *Client) Start() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
 
 			if serverID, err := strconv.Atoi(args[0]); err == nil {
-				_, _, err := c.Service.PowerOn(serverID)
+				_, _, err := c.Service.PowerOn(ctx, serverID)
 				if err != nil {
 					return errors.Wrap(err, "Could not start a Server")
 				}

--- a/internal/servers/stop.go
+++ b/internal/servers/stop.go
@@ -19,8 +19,10 @@ func (c *Client) Stop() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if serverID, err := strconv.Atoi(args[0]); err == nil {
-				_, _, err := c.Service.PowerOff(serverID)
+				_, _, err := c.Service.PowerOff(ctx, serverID)
 				if err != nil {
 					return errors.Wrap(err, "Could not stop a Server")
 				}

--- a/internal/servers/update.go
+++ b/internal/servers/update.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/cherryservers/cherryctl/internal/utils"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -29,6 +29,7 @@ func (c *Client) Update() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
 
 			if srvID, err := strconv.Atoi(args[0]); err == nil {
 				serverID = srvID
@@ -53,11 +54,14 @@ func (c *Client) Update() *cobra.Command {
 			request := &cherrygo.UpdateServer{
 				Name:     name,
 				Hostname: hostname,
-				Bgp:      bgp,
 				Tags:     &tagsArr,
 			}
 
-			s, _, err := c.Service.Update(serverID, request)
+			if cmd.Flags().Changed("bgp") {
+				request.BGP = &bgp
+			}
+
+			s, _, err := c.Service.Update(ctx, serverID, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not update server")
 			}

--- a/internal/servers/upgrade.go
+++ b/internal/servers/upgrade.go
@@ -22,13 +22,14 @@ func (c *Client) Upgrade() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
 
 			serverID, err := strconv.Atoi(args[0])
 			if err != nil {
 				return fmt.Errorf("failed to parse %q into server ID: %w", args[0], err)
 			}
 
-			_, _, err = c.Service.Upgrade(serverID, plan)
+			_, _, err = c.Service.Upgrade(ctx, serverID, plan)
 			if err != nil {
 				return fmt.Errorf("failed to upgrade server %d: %w", serverID, err)
 			}

--- a/internal/sshkeys/create.go
+++ b/internal/sshkeys/create.go
@@ -3,7 +3,7 @@ package sshkeys
 import (
 	"strconv"
 
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -22,12 +22,14 @@ func (c *Client) Create() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			request := &cherrygo.CreateSSHKey{
 				Label: label,
 				Key:   publicKey,
 			}
 
-			o, _, err := c.Service.Create(request)
+			o, _, err := c.Service.Create(ctx, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not create SSH key")
 			}

--- a/internal/sshkeys/delete.go
+++ b/internal/sshkeys/delete.go
@@ -25,6 +25,8 @@ func (c *Client) Delete() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if !force {
 				prompt := promptui.Prompt{
 					Label:     fmt.Sprintf("Are you sure you want to delete SSH key %d: ", sshKeyID),
@@ -36,7 +38,7 @@ func (c *Client) Delete() *cobra.Command {
 					return nil
 				}
 			}
-			_, _, err := c.Service.Delete(sshKeyID)
+			_, err := c.Service.Delete(ctx, sshKeyID)
 			if err != nil {
 				return errors.Wrap(err, "Could not delete SSH key")
 			}

--- a/internal/sshkeys/get.go
+++ b/internal/sshkeys/get.go
@@ -18,12 +18,14 @@ func (c *Client) Get() *cobra.Command {
   cherryctl ssh-key get 12345`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if sshID, err := strconv.Atoi(args[0]); err == nil {
 				sshKeyID = sshID
 			}
 			getOptions := c.Servicer.GetOptions()
 			getOptions.Fields = []string{"ssh_key", "email"}
-			o, _, err := c.Service.Get(sshKeyID, getOptions)
+			o, _, err := c.Service.Get(ctx, sshKeyID, getOptions)
 			if err != nil {
 				return errors.Wrap(err, "Could not get ssh-key")
 			}

--- a/internal/sshkeys/list.go
+++ b/internal/sshkeys/list.go
@@ -1,7 +1,7 @@
 package sshkeys
 
 import (
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -18,15 +18,17 @@ func (c *Client) List() *cobra.Command {
   cherryctl ssh-key list`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			getOptions := c.Servicer.GetOptions()
 			getOptions.Fields = []string{"ssh_key", "email"}
 
 			var sshKeys []cherrygo.SSHKey
 			err := error(nil)
 			if projectID != 0 {
-				sshKeys, _, err = c.ProjectsService.ListSSHKeys(projectID, getOptions)
+				sshKeys, _, err = c.ProjectsService.ListSSHKeys(ctx, projectID, getOptions)
 			} else {
-				sshKeys, _, err = c.Service.List(getOptions)
+				sshKeys, _, err = c.Service.List(ctx, getOptions)
 			}
 
 			if err != nil {

--- a/internal/sshkeys/sshkey.go
+++ b/internal/sshkeys/sshkey.go
@@ -2,7 +2,7 @@ package sshkeys
 
 import (
 	"github.com/cherryservers/cherryctl/internal/outputs"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/internal/sshkeys/update.go
+++ b/internal/sshkeys/update.go
@@ -3,7 +3,7 @@ package sshkeys
 import (
 	"strconv"
 
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -24,6 +24,8 @@ func (c *Client) Update() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if sshID, err := strconv.Atoi(args[0]); err == nil {
 				sshKeyID = sshID
 			}
@@ -37,7 +39,7 @@ func (c *Client) Update() *cobra.Command {
 				request.Key = &publicKey
 			}
 
-			o, _, err := c.Service.Update(sshKeyID, request)
+			o, _, err := c.Service.Update(ctx, sshKeyID, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not update SSH key")
 			}

--- a/internal/storages/attach.go
+++ b/internal/storages/attach.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	"github.com/cherryservers/cherryctl/internal/utils"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +27,8 @@ func (c *Client) Attach() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if storID, err := strconv.Atoi(args[0]); err == nil {
 				storageID = storID
 			}
@@ -36,7 +38,7 @@ func (c *Client) Attach() *cobra.Command {
 			}
 
 			request := &cherrygo.AttachTo{
-				StorageID: storageID,
+				AttachTo: serverID,
 			}
 
 			if serverHostname != "" {
@@ -44,14 +46,14 @@ func (c *Client) Attach() *cobra.Command {
 					fmt.Println("--project-id argument is required with --server-hostname.")
 					return nil
 				}
-				srvID, err := utils.ServerHostnameToID(serverHostname, projectID, c.ServerService)
+				srvID, err := utils.ServerHostnameToID(ctx, serverHostname, projectID, c.ServerService)
 				if err != nil {
 					return errors.Wrap(err, "Could not get a Server")
 				}
 				request.AttachTo = srvID
 			}
 
-			resp, _, err := c.Service.Attach(request)
+			resp, _, err := c.Service.Attach(ctx, storageID, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not atach storage to a server")
 			}

--- a/internal/storages/create.go
+++ b/internal/storages/create.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -25,14 +25,15 @@ func (c *Client) Create() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			request := &cherrygo.CreateStorage{
-				ProjectID:   projectID,
 				Description: description,
 				Size:        size,
 				Region:      region,
 			}
 
-			o, _, err := c.Service.Create(request)
+			o, _, err := c.Service.Create(ctx, projectID, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not create storage")
 			}

--- a/internal/storages/delete.go
+++ b/internal/storages/delete.go
@@ -27,6 +27,8 @@ func (c *Client) Delete() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if storID, err := strconv.Atoi(args[0]); err == nil {
 				storageID = storID
 			}
@@ -42,7 +44,7 @@ func (c *Client) Delete() *cobra.Command {
 				}
 			}
 
-			_, err := c.Service.Delete(storageID)
+			_, err := c.Service.Delete(ctx, storageID)
 			if err != nil {
 				return errors.Wrap(err, "Could not delete storage")
 			}

--- a/internal/storages/detach.go
+++ b/internal/storages/detach.go
@@ -22,11 +22,13 @@ func (c *Client) Detach() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if storID, err := strconv.Atoi(args[0]); err == nil {
 				storageID = storID
 			}
 
-			_, err := c.Service.Detach(storageID)
+			_, err := c.Service.Detach(ctx, storageID)
 			if err != nil {
 				return errors.Wrap(err, "Could not detach storage from a server")
 			}

--- a/internal/storages/get.go
+++ b/internal/storages/get.go
@@ -20,12 +20,14 @@ func (c *Client) Get() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if storID, err := strconv.Atoi(args[0]); err == nil {
 				storageID = storID
 			}
 			getOptions := c.Servicer.GetOptions()
 			getOptions.Fields = []string{"storage", "region", "id", "hostname"}
-			o, _, err := c.Service.Get(storageID, getOptions)
+			o, _, err := c.Service.Get(ctx, storageID, getOptions)
 			if err != nil {
 				return errors.Wrap(err, "Could not get storage")
 			}

--- a/internal/storages/list.go
+++ b/internal/storages/list.go
@@ -19,9 +19,11 @@ func (c *Client) List() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			getOptions := c.Servicer.GetOptions()
 			getOptions.Fields = []string{"storage", "region", "id", "hostname"}
-			storages, _, err := c.Service.List(projectID, getOptions)
+			storages, _, err := c.Service.List(ctx, projectID, getOptions)
 			if err != nil {
 				return errors.Wrap(err, "Could not get storage list")
 			}

--- a/internal/storages/storage.go
+++ b/internal/storages/storage.go
@@ -2,7 +2,7 @@ package storages
 
 import (
 	"github.com/cherryservers/cherryctl/internal/outputs"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/internal/storages/update.go
+++ b/internal/storages/update.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -25,16 +25,17 @@ func (c *Client) Update() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if storID, err := strconv.Atoi(args[0]); err == nil {
 				storageID = storID
 			}
 			request := &cherrygo.UpdateStorage{
-				StorageID:   storageID,
 				Size:        size,
 				Description: description,
 			}
 
-			o, _, err := c.Service.Update(request)
+			o, _, err := c.Service.Update(ctx, storageID, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not update storage")
 			}

--- a/internal/teams/create.go
+++ b/internal/teams/create.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -23,13 +23,15 @@ func (c *Client) Create() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			request := &cherrygo.CreateTeam{
 				Name:     name,
 				Type:     teamType,
 				Currency: currency,
 			}
 
-			o, _, err := c.Service.Create(request)
+			o, _, err := c.Service.Create(ctx, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not create a Team")
 			}

--- a/internal/teams/delete.go
+++ b/internal/teams/delete.go
@@ -26,6 +26,8 @@ func (c *Client) Delete() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if len(args) > 0 {
 				tID, err := strconv.Atoi(args[0])
 				if err == nil {
@@ -43,7 +45,7 @@ func (c *Client) Delete() *cobra.Command {
 					return nil
 				}
 			}
-			_, err := c.Service.Delete(teamID)
+			_, err := c.Service.Delete(ctx, teamID)
 			if err != nil {
 				return errors.Wrap(err, "Could not delete a Team")
 			}

--- a/internal/teams/get.go
+++ b/internal/teams/get.go
@@ -19,6 +19,8 @@ func (c *Client) Get() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			if len(args) > 0 {
 				tID, err := strconv.Atoi(args[0])
 				if err == nil {
@@ -30,7 +32,7 @@ func (c *Client) Get() *cobra.Command {
 				return fmt.Errorf("team-id should be set %v\t", teamID)
 			}
 
-			o, _, err := c.Service.Get(teamID, c.Servicer.GetOptions())
+			o, _, err := c.Service.Get(ctx, teamID, c.Servicer.GetOptions())
 			if err != nil {
 				return errors.Wrap(err, "Could not get team")
 			}

--- a/internal/teams/list.go
+++ b/internal/teams/list.go
@@ -19,7 +19,9 @@ func (c *Client) List() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			teams, _, err := c.Service.List(c.Servicer.GetOptions())
+			ctx := cmd.Context()
+
+			teams, _, err := c.Service.List(ctx, c.Servicer.GetOptions())
 			if err != nil {
 				return errors.Wrap(err, "Could not get teams list")
 			}

--- a/internal/teams/team.go
+++ b/internal/teams/team.go
@@ -2,7 +2,7 @@ package teams
 
 import (
 	"github.com/cherryservers/cherryctl/internal/outputs"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/internal/teams/update.go
+++ b/internal/teams/update.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -34,6 +34,8 @@ func (c *Client) Update() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			request := &cherrygo.UpdateTeam{}
 
 			if currency != "" {
@@ -48,7 +50,7 @@ func (c *Client) Update() *cobra.Command {
 				request.Type = &teamType
 			}
 
-			o, _, err := c.Service.Update(teamID, request)
+			o, _, err := c.Service.Update(ctx, teamID, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not update team")
 			}

--- a/internal/users/get.go
+++ b/internal/users/get.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -22,6 +22,8 @@ func (c *Client) Get() *cobra.Command {
 		cherryctl user get 123`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			ctx := cmd.Context()
+
 			var user cherrygo.User
 			var err error
 			if len(args) > 0 {
@@ -31,12 +33,12 @@ func (c *Client) Get() *cobra.Command {
 				}
 			}
 			if userID == 0 {
-				user, _, err = c.Service.CurrentUser(c.Servicer.GetOptions())
+				user, _, err = c.Service.CurrentUser(ctx, c.Servicer.GetOptions())
 				if err != nil {
 					return errors.Wrap(err, "Could not get current User")
 				}
 			} else {
-				user, _, err = c.Service.Get(userID, c.Servicer.GetOptions())
+				user, _, err = c.Service.Get(ctx, userID, c.Servicer.GetOptions())
 				if err != nil {
 					return errors.Wrap(err, "Could not get Users")
 				}

--- a/internal/users/user.go
+++ b/internal/users/user.go
@@ -2,7 +2,7 @@ package users
 
 import (
 	"github.com/cherryservers/cherryctl/internal/outputs"
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -2,11 +2,12 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strings"
 
-	"github.com/cherryservers/cherrygo/v3"
+	"github.com/cherryservers/cherrygo/v4"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
@@ -19,12 +20,12 @@ func BoolToYesNo(b bool) string {
 	return "no"
 }
 
-func ServerHostnameToID(hostname string, projectID int, ServerService cherrygo.ServersService) (int, error) {
+func ServerHostnameToID(ctx context.Context, hostname string, projectID int, ServerService cherrygo.ServersService) (int, error) {
 	if projectID == 0 {
 		return 0, fmt.Errorf("Project ID must be set")
 	}
 
-	serversList, err := serverList(projectID, ServerService)
+	serversList, err := serverList(ctx, projectID, ServerService)
 	for _, s := range serversList {
 		if strings.EqualFold(hostname, s.Hostname) {
 			return s.ID, err
@@ -34,11 +35,11 @@ func ServerHostnameToID(hostname string, projectID int, ServerService cherrygo.S
 	return 0, errors.Wrap(err, fmt.Sprintf("Could not find server with `%s` hostname", hostname))
 }
 
-func serverList(projectID int, ServerService cherrygo.ServersService) ([]cherrygo.Server, error) {
+func serverList(ctx context.Context, projectID int, ServerService cherrygo.ServersService) ([]cherrygo.Server, error) {
 	getOptions := cherrygo.GetOptions{
 		Fields: []string{"id", "name", "hostname"},
 	}
-	serverList, _, err := ServerService.List(projectID, &getOptions)
+	serverList, _, err := ServerService.List(ctx, projectID, &getOptions)
 
 	return serverList, err
 }


### PR DESCRIPTION
Do all the required adjustments for compatibility with the new major `cherrygo` version.

Based on https://github.com/cherryservers/cherryctl/pull/75.