### PR TITLE
Add server creation command tests

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -92,7 +92,7 @@ func (cli *Cli) RegisterCommands(client *root.Client) {
 		docs.NewCommand(),
 
 		initPck.NewClient(client).NewCommand(),
-		servers.NewClient(&serverDeps{client: client, sharedDeps: shared}).NewCommand(),
+		servers.NewCommand(&serverDeps{client: client, sharedDeps: shared}).CobraCommand(),
 		ips.NewClient(client, cli.Outputer).NewCommand(),
 		storages.NewClient(client, cli.Outputer).NewCommand(),
 		backups.NewClient(client, cli.Outputer).NewCommand(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,7 +64,6 @@ func (d sharedDeps) Outputer() outputs.Outputer {
 }
 
 type planDeps struct {
-	client *root.Client
 	sharedDeps
 }
 
@@ -75,7 +74,6 @@ func (d *planDeps) Client() cherrygo.PlansService {
 }
 
 type serverDeps struct {
-	client *root.Client
 	sharedDeps
 }
 
@@ -92,14 +90,14 @@ func (cli *Cli) RegisterCommands(client *root.Client) {
 		docs.NewCommand(),
 
 		initPck.NewClient(client).NewCommand(),
-		servers.NewCommand(&serverDeps{client: client, sharedDeps: shared}).CobraCommand(),
+		servers.NewCommand(&serverDeps{sharedDeps: shared}).CobraCommand(),
 		ips.NewClient(client, cli.Outputer).NewCommand(),
 		storages.NewClient(client, cli.Outputer).NewCommand(),
 		backups.NewClient(client, cli.Outputer).NewCommand(),
 		regions.NewClient(client, cli.Outputer).NewCommand(),
 		// We don't have the dependencies initialized yet, as that's done
 		// on pre-execution, so we need an injector interface.
-		plans.NewCommand(&planDeps{client: client, sharedDeps: shared}).CobraCommand(),
+		plans.NewCommand(&planDeps{sharedDeps: shared}).CobraCommand(),
 		projects.NewClient(client, cli.Outputer).NewCommand(),
 		teams.NewClient(client, cli.Outputer).NewCommand(),
 		sshkeys.NewClient(client, cli.Outputer).NewCommand(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,9 +50,22 @@ func NewCli() *Cli {
 	return cli
 }
 
+type sharedDeps struct {
+	out    outputs.Outputer
+	client *root.Client
+}
+
+func (d sharedDeps) GetOpts() *cherrygo.GetOptions {
+	return d.client.GetOptions()
+}
+
+func (d sharedDeps) Outputer() outputs.Outputer {
+	return d.out
+}
+
 type planDeps struct {
 	client *root.Client
-	out    outputs.Outputer
+	sharedDeps
 }
 
 func (d *planDeps) Client() cherrygo.PlansService {
@@ -61,27 +74,32 @@ func (d *planDeps) Client() cherrygo.PlansService {
 	return d.client.API(nil).Plans
 }
 
-func (d *planDeps) GetOpts() *cherrygo.GetOptions {
-	return d.client.GetOptions()
+type serverDeps struct {
+	client *root.Client
+	sharedDeps
 }
 
-func (d *planDeps) Outputer() outputs.Outputer {
-	return d.out
+func (d *serverDeps) Client() cherrygo.ServersService {
+	return d.client.API(nil).Servers
 }
 
 func (cli *Cli) RegisterCommands(client *root.Client) {
+	shared := sharedDeps{
+		out:    cli.Outputer,
+		client: client,
+	}
 	cli.MainCmd.AddCommand(
 		docs.NewCommand(),
 
 		initPck.NewClient(client).NewCommand(),
-		servers.NewClient(client, cli.Outputer).NewCommand(),
+		servers.NewClient(&serverDeps{client: client, sharedDeps: shared}).NewCommand(),
 		ips.NewClient(client, cli.Outputer).NewCommand(),
 		storages.NewClient(client, cli.Outputer).NewCommand(),
 		backups.NewClient(client, cli.Outputer).NewCommand(),
 		regions.NewClient(client, cli.Outputer).NewCommand(),
 		// We don't have the dependencies initialized yet, as that's done
 		// on pre-execution, so we need an injector interface.
-		plans.NewCommand(&planDeps{client: client, out: cli.Outputer}).CobraCommand(),
+		plans.NewCommand(&planDeps{client: client, sharedDeps: shared}).CobraCommand(),
 		projects.NewClient(client, cli.Outputer).NewCommand(),
 		teams.NewClient(client, cli.Outputer).NewCommand(),
 		sshkeys.NewClient(client, cli.Outputer).NewCommand(),

--- a/internal/fakes/output.go
+++ b/internal/fakes/output.go
@@ -4,11 +4,12 @@ import "github.com/cherryservers/cherryctl/internal/outputs"
 
 type Outputer struct {
 	Calls []OutputRecord
+	Err   error
 }
 
 func (o *Outputer) Output(in any, th []string, td *[][]string) error {
 	o.Calls = append(o.Calls, OutputRecord{in: in, th: th, td: *td})
-	return nil
+	return o.Err
 }
 
 func (o *Outputer) SetFormat(outputs.Format) {

--- a/internal/fakes/server.go
+++ b/internal/fakes/server.go
@@ -2,11 +2,15 @@ package fakes
 
 import (
 	"context"
+
 	"github.com/cherryservers/cherrygo/v4"
 )
 
+type ServerCreationFunc func(context.Context, *cherrygo.CreateServer) (cherrygo.Server, *cherrygo.Response, error)
+
 type ServerService struct {
-	Calls []CallRecord
+	Calls  []CallRecord
+	create ServerCreationFunc
 }
 
 // AllowBMCAccess implements [cherrygo.ServersService].
@@ -14,10 +18,14 @@ func (s *ServerService) AllowBMCAccess(ctx context.Context, serverID int, ip4 st
 	panic("unimplemented")
 }
 
+func (s *ServerService) SetCreate(f ServerCreationFunc) {
+	s.create = f
+}
+
 // Create implements [cherrygo.ServersService].
 func (s *ServerService) Create(ctx context.Context, request *cherrygo.CreateServer) (cherrygo.Server, *cherrygo.Response, error) {
 	s.Calls = append(s.Calls, CallRecord{method: "Create", params: []any{request}})
-	return cherrygo.Server{ID: 1}, nil, nil
+	return s.create(ctx, request)
 }
 
 // Delete implements [cherrygo.ServersService].

--- a/internal/fakes/server.go
+++ b/internal/fakes/server.go
@@ -15,7 +15,7 @@ type ServerService struct {
 
 // AllowBMCAccess implements [cherrygo.ServersService].
 func (s *ServerService) AllowBMCAccess(ctx context.Context, serverID int, ip4 string) (cherrygo.Server, *cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }
 
 func (s *ServerService) SetCreate(f ServerCreationFunc) {
@@ -30,80 +30,80 @@ func (s *ServerService) Create(ctx context.Context, request *cherrygo.CreateServ
 
 // Delete implements [cherrygo.ServersService].
 func (s *ServerService) Delete(ctx context.Context, serverID int) (*cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }
 
 // EnterRescueMode implements [cherrygo.ServersService].
 func (s *ServerService) EnterRescueMode(ctx context.Context, serverID int, fields *cherrygo.RescueServerFields) (cherrygo.Server, *cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }
 
 // ExitRescueMode implements [cherrygo.ServersService].
 func (s *ServerService) ExitRescueMode(ctx context.Context, serverID int) (cherrygo.Server, *cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }
 
 // Get implements [cherrygo.ServersService].
 func (s *ServerService) Get(ctx context.Context, serverID int, opts *cherrygo.GetOptions) (cherrygo.Server, *cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }
 
 // List implements [cherrygo.ServersService].
 func (s *ServerService) List(ctx context.Context, projectID int, opts *cherrygo.GetOptions) ([]cherrygo.Server, *cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }
 
 // ListCycles implements [cherrygo.ServersService].
 func (s *ServerService) ListCycles(ctx context.Context, opts *cherrygo.GetOptions) ([]cherrygo.ServerCycle, *cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }
 
 // ListSSHKeys implements [cherrygo.ServersService].
 func (s *ServerService) ListSSHKeys(ctx context.Context, serverID int, opts *cherrygo.GetOptions) ([]cherrygo.SSHKey, *cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }
 
 // PowerOff implements [cherrygo.ServersService].
 func (s *ServerService) PowerOff(ctx context.Context, serverID int) (cherrygo.Server, *cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }
 
 // PowerOn implements [cherrygo.ServersService].
 func (s *ServerService) PowerOn(ctx context.Context, serverID int) (cherrygo.Server, *cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }
 
 // PowerState implements [cherrygo.ServersService].
 func (s *ServerService) PowerState(ctx context.Context, serverID int) (cherrygo.PowerState, *cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }
 
 // Reboot implements [cherrygo.ServersService].
 func (s *ServerService) Reboot(ctx context.Context, serverID int) (cherrygo.Server, *cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }
 
 // Reinstall implements [cherrygo.ServersService].
 func (s *ServerService) Reinstall(ctx context.Context, serverID int, fields *cherrygo.ReinstallServerFields) (cherrygo.Server, *cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }
 
 // ResetBMCPassword implements [cherrygo.ServersService].
 func (s *ServerService) ResetBMCPassword(ctx context.Context, serverID int) (cherrygo.Server, *cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }
 
 // Update implements [cherrygo.ServersService].
 func (s *ServerService) Update(ctx context.Context, serverID int, request *cherrygo.UpdateServer) (cherrygo.Server, *cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }
 
 // Upgrade implements [cherrygo.ServersService].
 func (s *ServerService) Upgrade(ctx context.Context, serverID int, plan string) (cherrygo.Server, *cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }
 
 // WaitForStatus implements [cherrygo.ServersService].
 func (s *ServerService) WaitForStatus(ctx context.Context, serverID int, status cherrygo.ServerStatus) (cherrygo.Server, *cherrygo.Response, error) {
-	panic("unimplemented")
+	panic("not implemented")
 }

--- a/internal/fakes/server.go
+++ b/internal/fakes/server.go
@@ -1,0 +1,101 @@
+package fakes
+
+import (
+	"context"
+	"github.com/cherryservers/cherrygo/v4"
+)
+
+type ServerService struct {
+	Calls []CallRecord
+}
+
+// AllowBMCAccess implements [cherrygo.ServersService].
+func (s *ServerService) AllowBMCAccess(ctx context.Context, serverID int, ip4 string) (cherrygo.Server, *cherrygo.Response, error) {
+	panic("unimplemented")
+}
+
+// Create implements [cherrygo.ServersService].
+func (s *ServerService) Create(ctx context.Context, request *cherrygo.CreateServer) (cherrygo.Server, *cherrygo.Response, error) {
+	s.Calls = append(s.Calls, CallRecord{method: "Create", params: []any{request}})
+	return cherrygo.Server{ID: 1}, nil, nil
+}
+
+// Delete implements [cherrygo.ServersService].
+func (s *ServerService) Delete(ctx context.Context, serverID int) (*cherrygo.Response, error) {
+	panic("unimplemented")
+}
+
+// EnterRescueMode implements [cherrygo.ServersService].
+func (s *ServerService) EnterRescueMode(ctx context.Context, serverID int, fields *cherrygo.RescueServerFields) (cherrygo.Server, *cherrygo.Response, error) {
+	panic("unimplemented")
+}
+
+// ExitRescueMode implements [cherrygo.ServersService].
+func (s *ServerService) ExitRescueMode(ctx context.Context, serverID int) (cherrygo.Server, *cherrygo.Response, error) {
+	panic("unimplemented")
+}
+
+// Get implements [cherrygo.ServersService].
+func (s *ServerService) Get(ctx context.Context, serverID int, opts *cherrygo.GetOptions) (cherrygo.Server, *cherrygo.Response, error) {
+	panic("unimplemented")
+}
+
+// List implements [cherrygo.ServersService].
+func (s *ServerService) List(ctx context.Context, projectID int, opts *cherrygo.GetOptions) ([]cherrygo.Server, *cherrygo.Response, error) {
+	panic("unimplemented")
+}
+
+// ListCycles implements [cherrygo.ServersService].
+func (s *ServerService) ListCycles(ctx context.Context, opts *cherrygo.GetOptions) ([]cherrygo.ServerCycle, *cherrygo.Response, error) {
+	panic("unimplemented")
+}
+
+// ListSSHKeys implements [cherrygo.ServersService].
+func (s *ServerService) ListSSHKeys(ctx context.Context, serverID int, opts *cherrygo.GetOptions) ([]cherrygo.SSHKey, *cherrygo.Response, error) {
+	panic("unimplemented")
+}
+
+// PowerOff implements [cherrygo.ServersService].
+func (s *ServerService) PowerOff(ctx context.Context, serverID int) (cherrygo.Server, *cherrygo.Response, error) {
+	panic("unimplemented")
+}
+
+// PowerOn implements [cherrygo.ServersService].
+func (s *ServerService) PowerOn(ctx context.Context, serverID int) (cherrygo.Server, *cherrygo.Response, error) {
+	panic("unimplemented")
+}
+
+// PowerState implements [cherrygo.ServersService].
+func (s *ServerService) PowerState(ctx context.Context, serverID int) (cherrygo.PowerState, *cherrygo.Response, error) {
+	panic("unimplemented")
+}
+
+// Reboot implements [cherrygo.ServersService].
+func (s *ServerService) Reboot(ctx context.Context, serverID int) (cherrygo.Server, *cherrygo.Response, error) {
+	panic("unimplemented")
+}
+
+// Reinstall implements [cherrygo.ServersService].
+func (s *ServerService) Reinstall(ctx context.Context, serverID int, fields *cherrygo.ReinstallServerFields) (cherrygo.Server, *cherrygo.Response, error) {
+	panic("unimplemented")
+}
+
+// ResetBMCPassword implements [cherrygo.ServersService].
+func (s *ServerService) ResetBMCPassword(ctx context.Context, serverID int) (cherrygo.Server, *cherrygo.Response, error) {
+	panic("unimplemented")
+}
+
+// Update implements [cherrygo.ServersService].
+func (s *ServerService) Update(ctx context.Context, serverID int, request *cherrygo.UpdateServer) (cherrygo.Server, *cherrygo.Response, error) {
+	panic("unimplemented")
+}
+
+// Upgrade implements [cherrygo.ServersService].
+func (s *ServerService) Upgrade(ctx context.Context, serverID int, plan string) (cherrygo.Server, *cherrygo.Response, error) {
+	panic("unimplemented")
+}
+
+// WaitForStatus implements [cherrygo.ServersService].
+func (s *ServerService) WaitForStatus(ctx context.Context, serverID int, status cherrygo.ServerStatus) (cherrygo.Server, *cherrygo.Response, error) {
+	panic("unimplemented")
+}

--- a/internal/servers/create.go
+++ b/internal/servers/create.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *Client) Create() *cobra.Command {
+func (c *Command) Create() *cobra.Command {
 	var (
 		projectID       int
 		hostname        string

--- a/internal/servers/create.go
+++ b/internal/servers/create.go
@@ -85,7 +85,7 @@ func (c *Client) Create() *cobra.Command {
 				ConfigureIPv6:   &enableIPv6,
 			}
 
-			s, _, err := c.Service.Create(ctx, request)
+			s, _, err := c.Client().Create(ctx, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not provision a server")
 			}
@@ -94,7 +94,7 @@ func (c *Client) Create() *cobra.Command {
 			data := make([][]string, 1)
 			data[0] = []string{strconv.Itoa(s.ID), s.Name, s.Hostname, s.Image, s.State, s.Region.Name}
 
-			return c.Out.Output(s, header, &data)
+			return c.Outputer().Output(s, header, &data)
 		},
 	}
 

--- a/internal/servers/create_test.go
+++ b/internal/servers/create_test.go
@@ -1,0 +1,202 @@
+package servers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cherryservers/cherryctl/internal/fakes"
+	"github.com/cherryservers/cherryctl/internal/outputs"
+	"github.com/cherryservers/cherrygo/v4"
+)
+
+type fakeDeps struct {
+	svc  *fakes.ServerService
+	out  *fakes.Outputer
+	opts *cherrygo.GetOptions
+}
+
+func (fd fakeDeps) GetOpts() *cherrygo.GetOptions {
+	return fd.opts
+}
+
+func (fd fakeDeps) Client() cherrygo.ServersService {
+	return fd.svc
+}
+
+func (fd fakeDeps) Outputer() outputs.Outputer {
+	return fd.out
+}
+
+func newTrue() *bool {
+	b := true
+	return &b
+}
+
+func TestCreate(t *testing.T) {
+	tmpDir := t.TempDir()
+	userdataPath := filepath.Join(tmpDir, "userdata")
+	ipxePath := filepath.Join(tmpDir, "ipxe")
+	err := os.WriteFile(userdataPath, []byte("test-userdata"), 0644)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = os.WriteFile(ipxePath, []byte("test-ipxe"), 0644)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	cases := []struct {
+		title       string
+		args        []string
+		wantReqBody *cherrygo.CreateServer
+	}{
+		{
+			title: "only required args",
+			args:  []string{"--project-id", "1", "--region", "test-region", "--plan", "test-plan"},
+			wantReqBody: &cherrygo.CreateServer{
+				ProjectID:     1,
+				Region:        "test-region",
+				Plan:          "test-plan",
+				SSHKeys:       []string{},
+				IPAddresses:   []string{},
+				Tags:          &map[string]string{},
+				ConfigureIPv6: new(bool),
+			},
+		},
+		{
+			title: "all args",
+			args: []string{
+				"--project-id",
+				"1",
+				"--region",
+				"test-region",
+				"--plan",
+				"test-plan",
+				"--hostname",
+				"test-hostname",
+				"--image",
+				"test-image",
+				"--ssh-keys",
+				"1,2",
+				"--ip-addresses",
+				"1,2",
+				"--os-partition-size",
+				"1",
+				"--tags",
+				"env=test",
+				"--spot-instance",
+				"--storage-id",
+				"1",
+				"--cycle",
+				"test-cycle",
+				"--discount",
+				"test-discount",
+				"--enable-ipv6",
+				"--ipxe-file",
+				ipxePath,
+				"--userdata-file",
+				userdataPath,
+			},
+			wantReqBody: &cherrygo.CreateServer{
+				ProjectID:       1,
+				Region:          "test-region",
+				Plan:            "test-plan",
+				Hostname:        "test-hostname",
+				Image:           "test-image",
+				SSHKeys:         []string{"1", "2"},
+				IPAddresses:     []string{"1", "2"},
+				OSPartitionSize: 1,
+				Tags:            &map[string]string{"env": "test"},
+				SpotInstance:    true,
+				StorageID:       1,
+				Cycle:           "test-cycle",
+				DiscountCode:    "test-discount",
+				ConfigureIPv6:   newTrue(),
+				IPXE:            "dGVzdC1pcHhl", // base64
+				UserData:        "dGVzdC11c2VyZGF0YQ==",
+			},
+		},
+		{
+			title: "shorthands",
+			args:  []string{"-p", "1", "--region", "test-region", "--plan", "test-plan"},
+			wantReqBody: &cherrygo.CreateServer{
+				ProjectID:     1,
+				Region:        "test-region",
+				Plan:          "test-plan",
+				SSHKeys:       []string{},
+				IPAddresses:   []string{},
+				Tags:          &map[string]string{},
+				ConfigureIPv6: new(bool),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.title, func(t *testing.T) {
+			var (
+				fakeSvc fakes.ServerService
+				fakeOut fakes.Outputer
+			)
+			dep := fakeDeps{svc: &fakeSvc, out: &fakeOut}
+			c := Command{Deps: dep}
+
+			cmd := c.Create()
+			cmd.SetArgs(tc.args)
+			cmd.SilenceUsage = true
+
+			err := cmd.Execute()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			if len(fakeSvc.Calls) != 1 {
+				t.Fatalf("want 1 api call, got %d", len(fakeSvc.Calls))
+			}
+			fakeSvc.Calls[0].AssertMethod(t, "Create")
+			fakeSvc.Calls[0].AssertParams(t, tc.wantReqBody)
+
+			if len(fakeOut.Calls) != 1 {
+				t.Fatalf("want 1 output call, got %d", len(fakeOut.Calls))
+			}
+			wantTh := []string{"ID", "Name", "Hostname", "Image", "State", "Region"}
+			wantTd := [][]string{{"1", "", "", "", "", ""}}
+			fakeOut.Calls[0].Assert(t, cherrygo.Server{ID: 1}, wantTh, wantTd)
+
+		})
+	}
+}
+
+func TestCreateWithErrorsExpected(t *testing.T) {
+	cases := []struct {
+		title string
+		args  []string
+	}{
+		{
+			title: "no project",
+			args:  []string{"--region", "test-region", "--plan", "test-plan"},
+		},
+		{
+			title: "no plan",
+			args:  []string{"--project-id", "1", "--region", "test-region"},
+		},
+		{
+			title: "no region",
+			args:  []string{"--project-id", "1", "--plan", "test-plan"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.title, func(t *testing.T) {
+			c := Command{}
+			cmd := c.Create()
+			cmd.SetArgs(tc.args)
+			cmd.SilenceUsage = true
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("error expected")
+			}
+		})
+	}
+}

--- a/internal/servers/create_test.go
+++ b/internal/servers/create_test.go
@@ -1,13 +1,18 @@
 package servers
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
+
+	"errors"
 
 	"github.com/cherryservers/cherryctl/internal/fakes"
 	"github.com/cherryservers/cherryctl/internal/outputs"
 	"github.com/cherryservers/cherrygo/v4"
+	"github.com/spf13/cobra"
 )
 
 type fakeDeps struct {
@@ -31,6 +36,26 @@ func (fd fakeDeps) Outputer() outputs.Outputer {
 func newTrue() *bool {
 	b := true
 	return &b
+}
+
+func setupCommand(t *testing.T, svc *fakes.ServerService, out *fakes.Outputer, args []string) *cobra.Command {
+	t.Helper()
+
+	dep := fakeDeps{svc: svc, out: out}
+	c := Command{Deps: dep}
+
+	cmd := c.Create()
+	cmd.SetArgs(args)
+	cmd.SilenceUsage = true
+	return cmd
+}
+
+func createOK(_ context.Context, _ *cherrygo.CreateServer) (cherrygo.Server, *cherrygo.Response, error) {
+	return cherrygo.Server{ID: 1}, nil, nil
+}
+
+func createErr(_ context.Context, _ *cherrygo.CreateServer) (cherrygo.Server, *cherrygo.Response, error) {
+	return cherrygo.Server{}, nil, errors.New("test-error")
 }
 
 func TestCreate(t *testing.T) {
@@ -130,6 +155,72 @@ func TestCreate(t *testing.T) {
 				ConfigureIPv6: new(bool),
 			},
 		},
+		{
+			title: "multiple tags",
+			args: []string{
+				"--project-id",
+				"1",
+				"--region",
+				"test-region",
+				"--plan",
+				"test-plan",
+				"--tags",
+				"first=foo,second=bar",
+			},
+			wantReqBody: &cherrygo.CreateServer{
+				ProjectID:     1,
+				Region:        "test-region",
+				Plan:          "test-plan",
+				SSHKeys:       []string{},
+				IPAddresses:   []string{},
+				Tags:          &map[string]string{"first": "foo", "second": "bar"},
+				ConfigureIPv6: new(bool),
+			},
+		},
+		{
+			title: "whitespace tags",
+			args: []string{
+				"--project-id",
+				"1",
+				"--region",
+				"test-region",
+				"--plan",
+				"test-plan",
+				"--tags",
+				"  first  =  foo ,  second=  bar ",
+			},
+			wantReqBody: &cherrygo.CreateServer{
+				ProjectID:     1,
+				Region:        "test-region",
+				Plan:          "test-plan",
+				SSHKeys:       []string{},
+				IPAddresses:   []string{},
+				Tags:          &map[string]string{"first": "foo", "second": "bar"},
+				ConfigureIPv6: new(bool),
+			},
+		},
+		{
+			title: "key only tag",
+			args: []string{
+				"--project-id",
+				"1",
+				"--region",
+				"test-region",
+				"--plan",
+				"test-plan",
+				"--tags",
+				"foo",
+			},
+			wantReqBody: &cherrygo.CreateServer{
+				ProjectID:     1,
+				Region:        "test-region",
+				Plan:          "test-plan",
+				SSHKeys:       []string{},
+				IPAddresses:   []string{},
+				Tags:          &map[string]string{"foo": ""},
+				ConfigureIPv6: new(bool),
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -138,12 +229,8 @@ func TestCreate(t *testing.T) {
 				fakeSvc fakes.ServerService
 				fakeOut fakes.Outputer
 			)
-			dep := fakeDeps{svc: &fakeSvc, out: &fakeOut}
-			c := Command{Deps: dep}
-
-			cmd := c.Create()
-			cmd.SetArgs(tc.args)
-			cmd.SilenceUsage = true
+			fakeSvc.SetCreate(createOK)
+			cmd := setupCommand(t, &fakeSvc, &fakeOut, tc.args)
 
 			err := cmd.Execute()
 			if err != nil {
@@ -169,33 +256,115 @@ func TestCreate(t *testing.T) {
 
 func TestCreateWithErrorsExpected(t *testing.T) {
 	cases := []struct {
-		title string
-		args  []string
+		title           string
+		args            []string
+		createFn        fakes.ServerCreationFunc
+		outputErr       error
+		wantMsg         *regexp.Regexp
+		wantSvcCalls    int
+		wantOutputCalls int
 	}{
 		{
-			title: "no project",
-			args:  []string{"--region", "test-region", "--plan", "test-plan"},
+			title:           "no project",
+			args:            []string{"--region", "test-region", "--plan", "test-plan"},
+			createFn:        createOK,
+			wantMsg:         regexp.MustCompile(`^required flag\(s\) \"project-id\" not set$`),
+			wantSvcCalls:    0,
+			wantOutputCalls: 0,
 		},
 		{
-			title: "no plan",
-			args:  []string{"--project-id", "1", "--region", "test-region"},
+			title:           "no plan",
+			args:            []string{"--project-id", "1", "--region", "test-region"},
+			createFn:        createOK,
+			wantMsg:         regexp.MustCompile(`^required flag\(s\) \"plan\" not set$`),
+			wantSvcCalls:    0,
+			wantOutputCalls: 0,
 		},
 		{
-			title: "no region",
-			args:  []string{"--project-id", "1", "--plan", "test-plan"},
+			title:           "no region",
+			args:            []string{"--project-id", "1", "--plan", "test-plan"},
+			createFn:        createOK,
+			wantMsg:         regexp.MustCompile(`^required flag\(s\) \"region\" not set$`),
+			wantSvcCalls:    0,
+			wantOutputCalls: 0,
+		},
+		{
+			title: "missing userdata file",
+			args: []string{
+				"--project-id",
+				"1",
+				"--region",
+				"test-region",
+				"--plan",
+				"test-plan",
+				"--userdata-file",
+				"no-file",
+			},
+			createFn:        createOK,
+			wantMsg:         regexp.MustCompile(`^failed to read user-data file: .+$`),
+			wantSvcCalls:    0,
+			wantOutputCalls: 0,
+		},
+		{
+			title: "missing ipxe file",
+			args: []string{
+				"--project-id",
+				"1",
+				"--region",
+				"test-region",
+				"--plan",
+				"test-plan",
+				"--ipxe-file",
+				"no-file",
+			},
+			createFn:        createOK,
+			wantMsg:         regexp.MustCompile(`^failed to read ipxe file: .+$`),
+			wantSvcCalls:    0,
+			wantOutputCalls: 0,
+		},
+		{
+			title:           "api error",
+			args:            []string{"--project-id", "1", "--region", "test-region", "--plan", "test-plan"},
+			createFn:        createErr,
+			wantMsg:         regexp.MustCompile(`^Could not provision a server: test-error$`),
+			wantSvcCalls:    1,
+			wantOutputCalls: 0,
+		},
+		{
+			title:           "output error",
+			args:            []string{"--project-id", "1", "--region", "test-region", "--plan", "test-plan"},
+			createFn:        createOK,
+			outputErr:       errors.New("test-error"),
+			wantMsg:         regexp.MustCompile(`^test-error$`),
+			wantSvcCalls:    1,
+			wantOutputCalls: 1,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.title, func(t *testing.T) {
-			c := Command{}
-			cmd := c.Create()
-			cmd.SetArgs(tc.args)
-			cmd.SilenceUsage = true
+			var (
+				fakeSvc fakes.ServerService
+				fakeOut fakes.Outputer
+			)
+			fakeSvc.SetCreate(tc.createFn)
+			fakeOut.Err = tc.outputErr
+			cmd := setupCommand(t, &fakeSvc, &fakeOut, tc.args)
 
 			err := cmd.Execute()
 			if err == nil {
-				t.Fatal("error expected")
+				t.Fatal("error shouldn't be nil")
+			}
+			if !tc.wantMsg.MatchString(err.Error()) {
+				t.Fatalf("expected error msg that matches regex %q, got %q", tc.wantMsg, err.Error())
+			}
+
+			if len(fakeSvc.Calls) != tc.wantSvcCalls {
+				t.Errorf("want %d api call, got %d", tc.wantSvcCalls, len(fakeSvc.Calls))
+			}
+
+			if len(fakeOut.Calls) != tc.wantOutputCalls {
+				t.Fatalf("want %d output call, got %d", tc.wantOutputCalls, len(fakeOut.Calls))
 			}
 		})
 	}

--- a/internal/servers/delete.go
+++ b/internal/servers/delete.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *Client) Delete() *cobra.Command {
+func (c *Command) Delete() *cobra.Command {
 	var force bool
 	deleteServerCmd := &cobra.Command{
 		Use:   `delete ID [-f]`,

--- a/internal/servers/delete.go
+++ b/internal/servers/delete.go
@@ -41,7 +41,7 @@ func (c *Client) Delete() *cobra.Command {
 			}
 
 			if serverID, err := strconv.Atoi(args[0]); err == nil {
-				_, err := c.Service.Delete(ctx, serverID)
+				_, err := c.Client().Delete(ctx, serverID)
 				if err != nil {
 					return errors.Wrap(err, "Could not delete Server")
 				}

--- a/internal/servers/enter_rescue.go
+++ b/internal/servers/enter_rescue.go
@@ -29,7 +29,7 @@ func (c *Client) EnterRescue() *cobra.Command {
 			}
 
 			if serverID, err := strconv.Atoi(args[0]); err == nil {
-				_, _, err := c.Service.EnterRescueMode(ctx, serverID, request)
+				_, _, err := c.Client().EnterRescueMode(ctx, serverID, request)
 				if err != nil {
 					return errors.Wrap(err, "Couldn't put server in rescue mode.")
 				}

--- a/internal/servers/enter_rescue.go
+++ b/internal/servers/enter_rescue.go
@@ -2,14 +2,15 @@ package servers
 
 import (
 	"fmt"
-	"github.com/cherryservers/cherrygo/v4"
 	"strconv"
+
+	"github.com/cherryservers/cherrygo/v4"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
-func (c *Client) EnterRescue() *cobra.Command {
+func (c *Command) EnterRescue() *cobra.Command {
 	var password string
 
 	enterRescueServerCmd := &cobra.Command{

--- a/internal/servers/exit_rescue.go
+++ b/internal/servers/exit_rescue.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *Client) ExitRescue() *cobra.Command {
+func (c *Command) ExitRescue() *cobra.Command {
 	exitRescueServerCmd := &cobra.Command{
 		Use:   `exit-rescue ID`,
 		Args:  cobra.ExactArgs(1),

--- a/internal/servers/exit_rescue.go
+++ b/internal/servers/exit_rescue.go
@@ -22,7 +22,7 @@ func (c *Client) ExitRescue() *cobra.Command {
 			ctx := cmd.Context()
 
 			if serverID, err := strconv.Atoi(args[0]); err == nil {
-				_, _, err := c.Service.ExitRescueMode(ctx, serverID)
+				_, _, err := c.Client().ExitRescueMode(ctx, serverID)
 				if err != nil {
 					return errors.Wrap(err, "Could not put server out of rescue mode.")
 				}

--- a/internal/servers/get.go
+++ b/internal/servers/get.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *Client) Get() *cobra.Command {
+func (c *Command) Get() *cobra.Command {
 	var serverID int
 	var projectID int
 	serverGetCmd := &cobra.Command{

--- a/internal/servers/get.go
+++ b/internal/servers/get.go
@@ -34,14 +34,14 @@ func (c *Client) Get() *cobra.Command {
 				if projectID == 0 {
 					return errors.Wrap(err, "server get by hostname requires project-id argument.")
 				}
-				srvID, err := utils.ServerHostnameToID(ctx, args[0], projectID, c.Service)
+				srvID, err := utils.ServerHostnameToID(ctx, args[0], projectID, c.Client())
 				if err != nil {
 					return errors.Wrap(err, "Server with hostname %s was not found")
 				}
 				serverID = srvID
 			}
 
-			s, _, err := c.Service.Get(ctx, serverID, c.Servicer.GetOptions())
+			s, _, err := c.Client().Get(ctx, serverID, c.GetOpts())
 			if err != nil {
 				return errors.Wrap(err, "Could not get a Server")
 			}
@@ -49,7 +49,7 @@ func (c *Client) Get() *cobra.Command {
 			data := make([][]string, 1)
 			data[0] = []string{strconv.Itoa(s.ID), s.Plan.Name, s.Hostname, s.Image, s.State, getServerIPByType(s, "primary-ip"), getServerIPByType(s, "private-ip"), s.Region.Name, utils.FormatStringTags(&s.Tags), utils.BoolToYesNo(s.SpotInstance)}
 
-			return c.Out.Output(s, header, &data)
+			return c.Outputer().Output(s, header, &data)
 		},
 	}
 

--- a/internal/servers/list.go
+++ b/internal/servers/list.go
@@ -26,14 +26,14 @@ func (c *Client) List() *cobra.Command {
 				return fmt.Errorf("project-id should be set %v\t", projectID)
 			}
 
-			options := c.Servicer.GetOptions()
+			options := c.GetOpts()
 
 			if search != "" {
 				options.QueryParams = map[string]string{"search": search}
 			}
 
 			cmd.SilenceUsage = true
-			servers, _, err := c.Service.List(ctx, projectID, options)
+			servers, _, err := c.Client().List(ctx, projectID, options)
 			if err != nil {
 				return errors.Wrap(err, "Could not list servers")
 			}
@@ -44,7 +44,7 @@ func (c *Client) List() *cobra.Command {
 			}
 			header := []string{"ID", "Name", "Hostname", "Image", "State", "Public IP", "Private IP", "Region", "Tags", "Spot"}
 
-			return c.Out.Output(servers, header, &data)
+			return c.Outputer().Output(servers, header, &data)
 		},
 	}
 

--- a/internal/servers/list.go
+++ b/internal/servers/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *Client) List() *cobra.Command {
+func (c *Command) List() *cobra.Command {
 	var projectID int
 	var search string
 	serverListCmd := &cobra.Command{

--- a/internal/servers/list_cycles.go
+++ b/internal/servers/list_cycles.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *Client) ListCycles() *cobra.Command {
+func (c *Command) ListCycles() *cobra.Command {
 	serverListCmd := &cobra.Command{
 		Use:   `list-cycles`,
 		Short: "Retrieves server billing cycle list.",

--- a/internal/servers/list_cycles.go
+++ b/internal/servers/list_cycles.go
@@ -16,11 +16,11 @@ func (c *Client) ListCycles() *cobra.Command {
 		cherryctl server list-cycles`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-			options := c.Servicer.GetOptions()
+			options := c.GetOpts()
 			ctx := cmd.Context()
 
 			cmd.SilenceUsage = true
-			cycles, _, err := c.Service.ListCycles(ctx, options)
+			cycles, _, err := c.Client().ListCycles(ctx, options)
 			if err != nil {
 				return errors.Wrap(err, "Could not list server billing cycles.")
 			}
@@ -31,7 +31,7 @@ func (c *Client) ListCycles() *cobra.Command {
 			}
 			header := []string{"ID", "Name", "Slug"}
 
-			return c.Out.Output(cycles, header, &data)
+			return c.Outputer().Output(cycles, header, &data)
 		},
 	}
 

--- a/internal/servers/reboot.go
+++ b/internal/servers/reboot.go
@@ -22,7 +22,7 @@ func (c *Client) Reboot() *cobra.Command {
 			ctx := cmd.Context()
 
 			if serverID, err := strconv.Atoi(args[0]); err == nil {
-				_, _, err := c.Service.Reboot(ctx, serverID)
+				_, _, err := c.Client().Reboot(ctx, serverID)
 				if err != nil {
 					return errors.Wrap(err, "Could not reboot a Server")
 				}

--- a/internal/servers/reboot.go
+++ b/internal/servers/reboot.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *Client) Reboot() *cobra.Command {
+func (c *Command) Reboot() *cobra.Command {
 	rebootServerCmd := &cobra.Command{
 		Use:   `reboot ID`,
 		Args:  cobra.ExactArgs(1),

--- a/internal/servers/reinstall.go
+++ b/internal/servers/reinstall.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *Client) Reinstall() *cobra.Command {
+func (c *Command) Reinstall() *cobra.Command {
 	var (
 		hostname        string
 		image           string

--- a/internal/servers/reinstall.go
+++ b/internal/servers/reinstall.go
@@ -55,7 +55,7 @@ func (c *Client) Reinstall() *cobra.Command {
 			}
 
 			if serverID, err := strconv.Atoi(args[0]); err == nil {
-				_, _, err := c.Service.Reinstall(ctx, serverID, request)
+				_, _, err := c.Client().Reinstall(ctx, serverID, request)
 				if err != nil {
 					return errors.Wrap(err, "Could not reinstall a Server.")
 				}

--- a/internal/servers/resetbmc.go
+++ b/internal/servers/resetbmc.go
@@ -2,12 +2,13 @@ package servers
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"strconv"
 )
 
-func (c *Client) ResetBMC() *cobra.Command {
+func (c *Command) ResetBMC() *cobra.Command {
 	resetServerBMCCmd := &cobra.Command{
 		Use:   `reset-bmc-password ID`,
 		Args:  cobra.ExactArgs(1),

--- a/internal/servers/resetbmc.go
+++ b/internal/servers/resetbmc.go
@@ -23,7 +23,7 @@ func (c *Client) ResetBMC() *cobra.Command {
 			ctx := cmd.Context()
 
 			if serverID, err := strconv.Atoi(args[0]); err == nil {
-				_, _, err := c.Service.ResetBMCPassword(ctx, serverID)
+				_, _, err := c.Client().ResetBMCPassword(ctx, serverID)
 				if err != nil {
 					return errors.Wrap(err, "Could not reset server BMC password")
 				}

--- a/internal/servers/server.go
+++ b/internal/servers/server.go
@@ -4,13 +4,10 @@ import (
 	"github.com/cherryservers/cherryctl/internal/outputs"
 	"github.com/cherryservers/cherrygo/v4"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 type Client struct {
-	Servicer Servicer
-	Service  cherrygo.ServersService
-	Out      outputs.Outputer
+	Deps
 }
 
 func (c *Client) NewCommand() *cobra.Command {
@@ -19,16 +16,6 @@ func (c *Client) NewCommand() *cobra.Command {
 		Aliases: []string{"servers", "device", "devices"},
 		Short:   "Server operations. For more information on server types, check the Product Docs: https://docs.cherryservers.com/knowledge/product-docs#compute",
 		Long:    "Server operations: create, get, list, delete, start, stop, reboot, reinstall, reset-bmc-password and list-cycles.",
-
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if root := cmd.Root(); root != nil {
-				if root.PersistentPreRun != nil {
-					root.PersistentPreRun(cmd, args)
-				}
-			}
-
-			c.Service = c.Servicer.API(cmd).Servers
-		},
 	}
 
 	cmd.AddCommand(
@@ -51,16 +38,15 @@ func (c *Client) NewCommand() *cobra.Command {
 	return cmd
 }
 
-type Servicer interface {
-	API(*cobra.Command) *cherrygo.Client
-	GetOptions() *cherrygo.GetOptions
-	Config(cmd *cobra.Command) *viper.Viper
+type Deps interface {
+	Client() cherrygo.ServersService
+	GetOpts() *cherrygo.GetOptions
+	Outputer() outputs.Outputer
 }
 
-func NewClient(s Servicer, out outputs.Outputer) *Client {
+func NewClient(dep Deps) *Client {
 	return &Client{
-		Servicer: s,
-		Out:      out,
+		Deps: dep,
 	}
 }
 

--- a/internal/servers/server.go
+++ b/internal/servers/server.go
@@ -6,11 +6,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type Client struct {
+type Command struct {
 	Deps
 }
 
-func (c *Client) NewCommand() *cobra.Command {
+func (c *Command) CobraCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     `server`,
 		Aliases: []string{"servers", "device", "devices"},
@@ -44,8 +44,8 @@ type Deps interface {
 	Outputer() outputs.Outputer
 }
 
-func NewClient(dep Deps) *Client {
-	return &Client{
+func NewCommand(dep Deps) *Command {
+	return &Command{
 		Deps: dep,
 	}
 }

--- a/internal/servers/start.go
+++ b/internal/servers/start.go
@@ -22,7 +22,7 @@ func (c *Client) Start() *cobra.Command {
 			ctx := cmd.Context()
 
 			if serverID, err := strconv.Atoi(args[0]); err == nil {
-				_, _, err := c.Service.PowerOn(ctx, serverID)
+				_, _, err := c.Client().PowerOn(ctx, serverID)
 				if err != nil {
 					return errors.Wrap(err, "Could not start a Server")
 				}

--- a/internal/servers/start.go
+++ b/internal/servers/start.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *Client) Start() *cobra.Command {
+func (c *Command) Start() *cobra.Command {
 	startServerCmd := &cobra.Command{
 		Use:   `start ID`,
 		Args:  cobra.ExactArgs(1),

--- a/internal/servers/stop.go
+++ b/internal/servers/stop.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *Client) Stop() *cobra.Command {
+func (c *Command) Stop() *cobra.Command {
 	stopServerCmd := &cobra.Command{
 		Use:   `stop ID`,
 		Args:  cobra.ExactArgs(1),

--- a/internal/servers/stop.go
+++ b/internal/servers/stop.go
@@ -22,7 +22,7 @@ func (c *Client) Stop() *cobra.Command {
 			ctx := cmd.Context()
 
 			if serverID, err := strconv.Atoi(args[0]); err == nil {
-				_, _, err := c.Service.PowerOff(ctx, serverID)
+				_, _, err := c.Client().PowerOff(ctx, serverID)
 				if err != nil {
 					return errors.Wrap(err, "Could not stop a Server")
 				}

--- a/internal/servers/update.go
+++ b/internal/servers/update.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *Client) Update() *cobra.Command {
+func (c *Command) Update() *cobra.Command {
 	var (
 		serverID int
 		tags     []string

--- a/internal/servers/update.go
+++ b/internal/servers/update.go
@@ -61,7 +61,7 @@ func (c *Client) Update() *cobra.Command {
 				request.BGP = &bgp
 			}
 
-			s, _, err := c.Service.Update(ctx, serverID, request)
+			s, _, err := c.Client().Update(ctx, serverID, request)
 			if err != nil {
 				return errors.Wrap(err, "Could not update server")
 			}
@@ -70,7 +70,7 @@ func (c *Client) Update() *cobra.Command {
 			data := make([][]string, 1)
 			data[0] = []string{strconv.Itoa(s.ID), s.Name, s.Hostname, s.Image, s.State, s.Region.Name, utils.FormatStringTags(&s.Tags)}
 
-			return c.Out.Output(s, header, &data)
+			return c.Outputer().Output(s, header, &data)
 		},
 	}
 

--- a/internal/servers/upgrade.go
+++ b/internal/servers/upgrade.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *Client) Upgrade() *cobra.Command {
+func (c *Command) Upgrade() *cobra.Command {
 	var (
 		plan string
 	)

--- a/internal/servers/upgrade.go
+++ b/internal/servers/upgrade.go
@@ -29,7 +29,7 @@ func (c *Client) Upgrade() *cobra.Command {
 				return fmt.Errorf("failed to parse %q into server ID: %w", args[0], err)
 			}
 
-			_, _, err = c.Service.Upgrade(ctx, serverID, plan)
+			_, _, err = c.Client().Upgrade(ctx, serverID, plan)
 			if err != nil {
 				return fmt.Errorf("failed to upgrade server %d: %w", serverID, err)
 			}


### PR DESCRIPTION
Refactors server command structure along the lines of the plan command. This reduces dependency scope, simplifies injection, improves naming. Based on these refactors, add unit tests that cover the server creation command.

Closes https://github.com/cherryservers/cherryctl/issues/80.