### PR TITLE
Bump `cherrygo` to `v4.1.0`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cherryservers/cherryctl
 go 1.25.0
 
 require (
-	github.com/cherryservers/cherrygo/v4 v4.0.0
+	github.com/cherryservers/cherrygo/v4 v4.1.0
 	github.com/google/uuid v1.6.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cherryservers/cherrygo/v4 v4.0.0 h1:EGQcXESCPz/h/UP8PmlmUhz+2CO4sXqZatJ4IqsDWmA=
-github.com/cherryservers/cherrygo/v4 v4.0.0/go.mod h1:ZJk3JYeFSqSPQ7HIkJa2rOdq0L2mI2Oy3iZwTbWnJgg=
+github.com/cherryservers/cherrygo/v4 v4.1.0 h1:ksGX3q3faWvS3lFf6PTA9wAemPWhH2qbk2ulkTssUX8=
+github.com/cherryservers/cherrygo/v4 v4.1.0/go.mod h1:ZJk3JYeFSqSPQ7HIkJa2rOdq0L2mI2Oy3iZwTbWnJgg=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=


### PR DESCRIPTION
`v4.1.0` has some important fixes that we should get in before the next release.