### PR TITLE
Fix getting server by hostname error message

### DIFF
--- a/internal/servers/get.go
+++ b/internal/servers/get.go
@@ -36,7 +36,7 @@ func (c *Client) Get() *cobra.Command {
 				}
 				srvID, err := utils.ServerHostnameToID(ctx, args[0], projectID, c.Service)
 				if err != nil {
-					return errors.Wrap(err, "Server with hostname %s was not found")
+					return err
 				}
 				serverID = srvID
 			}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cherryservers/cherrygo/v4"
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 )
 
 func BoolToYesNo(b bool) string {
@@ -26,13 +25,16 @@ func ServerHostnameToID(ctx context.Context, hostname string, projectID int, Ser
 	}
 
 	serversList, err := serverList(ctx, projectID, ServerService)
+	if err != nil {
+		return 0, err
+	}
 	for _, s := range serversList {
 		if strings.EqualFold(hostname, s.Hostname) {
 			return s.ID, err
 		}
 	}
 
-	return 0, errors.Wrap(err, fmt.Sprintf("Could not find server with `%s` hostname", hostname))
+	return 0, fmt.Errorf("Could not find server with `%s` hostname", hostname)
 }
 
 func serverList(ctx context.Context, projectID int, ServerService cherrygo.ServersService) ([]cherrygo.Server, error) {


### PR DESCRIPTION
`errors.Wrap` doesn't do formatting, but wrapping the error isn't really required here, as the message returned from `ServerHostnameToID` is descriptive enough. Also fixes a related bug in `utils.ServerHostnameToID`, where it would return a `nil` error, despite not having found a server, due to wrapping a `nil` API error.

Closes https://github.com/cherryservers/cherryctl/issues/81.